### PR TITLE
Add timerouts to provide detailed timing information

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Distributions
 Clp
 JSON
 Compat 0.17
+TimerOutputs

--- a/examples/BinaryProblems/booking_management.jl
+++ b/examples/BinaryProblems/booking_management.jl
@@ -88,5 +88,5 @@ m_1_2_5 = bookingmanagementmodel(1, 2, 5)
 
 srand(1234)
 m_2_2_3 = bookingmanagementmodel(2, 2, 3)
-@test solve(m_2_2_3, max_iterations = 40, print_level = 1) == :max_iterations
+@test solve(m_2_2_3, max_iterations = 40, print_level = 2) == :max_iterations
 @test isapprox(getbound(m_2_2_3), 6.13, atol=0.001)

--- a/src/JuMPfunctions.jl
+++ b/src/JuMPfunctions.jl
@@ -31,143 +31,147 @@ function jumpsolve(m::JuMP.Model; suppress_warnings=false,
     end
 
     isempty(kwargs) || error("Unrecognized keyword arguments: $(join([k[1] for k in kwargs], ", "))")
+    @timeit TIMER "prep JuMP model" begin
+        # Clear warning counters
+        m.map_counter = 0
+        m.operator_counter = 0
 
-    # Clear warning counters
-    m.map_counter = 0
-    m.operator_counter = 0
+        # Remember if the solver was initially unset so we can restore
+        # it to be unset later
+        unset = m.solver == JuMP.UnsetSolver()
 
-    # Remember if the solver was initially unset so we can restore
-    # it to be unset later
-    unset = m.solver == JuMP.UnsetSolver()
+        # Analyze the problems traits to determine what solvers we can use
+        traits = JuMP.ProblemTraits(m, relaxation)
 
-    # Analyze the problems traits to determine what solvers we can use
-    traits = JuMP.ProblemTraits(m, relaxation=relaxation)
+        # Build the MathProgBase model from the JuMP model
+        JuMP.build(m, traits=traits, suppress_warnings=suppress_warnings, relaxation=relaxation)
 
-    # Build the MathProgBase model from the JuMP model
-    JuMP.build(m, traits=traits, suppress_warnings=suppress_warnings, relaxation=relaxation)
-
-    # If the model is a general nonlinear, use different logic in
-    # nlp.jl to solve the problem
-    traits.nlp && return JuMP.solvenlp(m, traits, suppress_warnings=suppress_warnings)
-
+        # If the model is a general nonlinear, use different logic in
+        # nlp.jl to solve the problem
+        traits.nlp && return JuMP.solvenlp(m, traits, suppress_warnings=suppress_warnings)
+    end
     # Solve the problem
-    JuMP.MathProgBase.optimize!(m.internalModel)
-    stat::Symbol = JuMP.MathProgBase.status(m.internalModel)
+    @timeit TIMER "optimize!" begin
+        JuMP.MathProgBase.optimize!(m.internalModel)
+    end
 
-    # Extract solution from the solver
-    numRows, numCols = length(m.linconstr), m.numCols
-    m.objBound = NaN
-    m.objVal = NaN
-    m.colVal = fill(NaN, numCols)
-    m.linconstrDuals = Array{Float64}(0)
+    @timeit TIMER "getsolution" begin
+        stat::Symbol = JuMP.MathProgBase.status(m.internalModel)
 
-    discrete = !relaxation && (traits.int || traits.sos)
-    if stat == :Optimal
-        # If we think dual information might be available, try to get it
-        # If not, return an array of the correct length
-        if discrete
-            m.redCosts = fill(NaN, numCols)
-            m.linconstrDuals = fill(NaN, numRows)
+        # Extract solution from the solver
+        numRows, numCols = length(m.linconstr), m.numCols
+        m.objBound = NaN
+        m.objVal = NaN
+        m.colVal = fill(NaN, numCols)
+        m.linconstrDuals = Array{Float64}(0)
+
+        discrete = !relaxation && (traits.int || traits.sos)
+        if stat == :Optimal
+            # If we think dual information might be available, try to get it
+            # If not, return an array of the correct length
+            if discrete
+                m.redCosts = fill(NaN, numCols)
+                m.linconstrDuals = fill(NaN, numRows)
+            else
+                if !traits.conic
+                    m.redCosts = try
+                        JuMP.MathProgBase.getreducedcosts(m.internalModel)[1:numCols]
+                    catch
+                        fill(NaN, numCols)
+                    end
+
+                    m.linconstrDuals = try
+                        JuMP.MathProgBase.getconstrduals(m.internalModel)[1:numRows]
+                    catch
+                        fill(NaN, numRows)
+                    end
+                elseif !traits.qp && !traits.qc
+                    fillConicDuals(m)
+                end
+            end
         else
-            if !traits.conic
-                m.redCosts = try
-                    JuMP.MathProgBase.getreducedcosts(m.internalModel)[1:numCols]
-                catch
-                    fill(NaN, numCols)
+            # Problem was not solved to optimality, attempt to extract useful
+            # information anyway
+            suppress_warnings || warn("Not solved to optimality, status: $stat")
+            # Some solvers provide infeasibility rays (dual) or unbounded
+            # rays (primal) for linear problems. Store these as the solution
+            # if the exist.
+            if traits.lin
+                if stat == :Infeasible
+                    m.linconstrDuals = try
+                        infray = JuMP.MathProgBase.getinfeasibilityray(m.internalModel)
+                        @assert length(infray) == numRows
+                        infray
+                    catch
+                        suppress_warnings || warn("Infeasibility ray (Farkas proof) not available")
+                        fill(NaN, numRows)
+                    end
+                elseif stat == :Unbounded
+                    m.colVal = try
+                        unbdray = JuMP.MathProgBase.getunboundedray(m.internalModel)
+                        @assert length(unbdray) == numCols
+                        unbdray
+                    catch
+                        suppress_warnings || warn("Unbounded ray not available")
+                        fill(NaN, numCols)
+                    end
                 end
+            end
+            # conic duals (currently, SOC and SDP only)
+            if !discrete && traits.conic && !traits.qp && !traits.qc
+                if stat == :Infeasible
+                    fillConicDuals(m)
+                end
+            end
+        end
 
-                m.linconstrDuals = try
-                    JuMP.MathProgBase.getconstrduals(m.internalModel)[1:numRows]
-                catch
-                    fill(NaN, numRows)
-                end
-            elseif !traits.qp && !traits.qc
-                fillConicDuals(m)
-            end
-        end
-    else
-        # Problem was not solved to optimality, attempt to extract useful
-        # information anyway
-        suppress_warnings || warn("Not solved to optimality, status: $stat")
-        # Some solvers provide infeasibility rays (dual) or unbounded
-        # rays (primal) for linear problems. Store these as the solution
-        # if the exist.
-        if traits.lin
-            if stat == :Infeasible
-                m.linconstrDuals = try
-                    infray = JuMP.MathProgBase.getinfeasibilityray(m.internalModel)
-                    @assert length(infray) == numRows
-                    infray
-                catch
-                    suppress_warnings || warn("Infeasibility ray (Farkas proof) not available")
-                    fill(NaN, numRows)
-                end
-            elseif stat == :Unbounded
-                m.colVal = try
-                    unbdray = JuMP.MathProgBase.getunboundedray(m.internalModel)
-                    @assert length(unbdray) == numCols
-                    unbdray
-                catch
-                    suppress_warnings || warn("Unbounded ray not available")
-                    fill(NaN, numCols)
+        # If the problem was solved, or if it terminated prematurely, try
+        # to extract a solution anyway. This commonly occurs when a time
+        # limit or tolerance is set (:UserLimit)
+        if !(stat == :Infeasible || stat == :Unbounded)
+            if discrete
+                try
+                    # Do a separate try since getobjval could work while getobjbound does not and vice versa
+                    objBound = JuMP.MathProgBase.getobjbound(m.internalModel) + m.obj.aff.constant
+                    m.objBound = objBound
                 end
             end
-        end
-        # conic duals (currently, SOC and SDP only)
-        if !discrete && traits.conic && !traits.qp && !traits.qc
-            if stat == :Infeasible
-                fillConicDuals(m)
-            end
-        end
-    end
-
-    # If the problem was solved, or if it terminated prematurely, try
-    # to extract a solution anyway. This commonly occurs when a time
-    # limit or tolerance is set (:UserLimit)
-    if !(stat == :Infeasible || stat == :Unbounded)
-        if discrete
             try
-                # Do a separate try since getobjval could work while getobjbound does not and vice versa
-                objBound = JuMP.MathProgBase.getobjbound(m.internalModel) + m.obj.aff.constant
-                m.objBound = objBound
+                objVal = JuMP.MathProgBase.getobjval(m.internalModel) + m.obj.aff.constant
+                colVal = JuMP.MathProgBase.getsolution(m.internalModel)[1:numCols]
+                # Rescale off-diagonal terms of SDP variables
+                if traits.sdp
+                    offdiagvars = offdiagsdpvars(m)
+                    colVal[offdiagvars] /= sqrt(2)
+                end
+                # Don't corrupt the answers if one of the above two calls fails
+                m.objVal = objVal
+                m.colVal = colVal
             end
         end
-        try
-            objVal = JuMP.MathProgBase.getobjval(m.internalModel) + m.obj.aff.constant
-            colVal = JuMP.MathProgBase.getsolution(m.internalModel)[1:numCols]
-            # Rescale off-diagonal terms of SDP variables
-            if traits.sdp
-                offdiagvars = offdiagsdpvars(m)
-                colVal[offdiagvars] /= sqrt(2)
+
+        # The MathProgBase interface defines a conic problem to always be
+        # a minimization problem, so we need to flip the objective before
+        # reporting it to the user
+        if traits.conic && m.objSense == :Max
+            m.objBound *= -1
+            m.objVal *= -1
+        end
+
+        # If the solver was initially not set, we will restore this status
+        # and drop the internal MPB model. This is important for the case
+        # where the solver used changes between solves because the user
+        # has changed the problem class (e.g. LP to MILP)
+        if unset
+            m.solver = JuMP.UnsetSolver()
+            if traits.int
+                m.internalModelLoaded = false
             end
-            # Don't corrupt the answers if one of the above two calls fails
-            m.objVal = objVal
-            m.colVal = colVal
         end
+
+        # don't keep relaxed model in memory
+        relaxation && (m.internalModelLoaded = false)
     end
-
-    # The MathProgBase interface defines a conic problem to always be
-    # a minimization problem, so we need to flip the objective before
-    # reporting it to the user
-    if traits.conic && m.objSense == :Max
-        m.objBound *= -1
-        m.objVal *= -1
-    end
-
-    # If the solver was initially not set, we will restore this status
-    # and drop the internal MPB model. This is important for the case
-    # where the solver used changes between solves because the user
-    # has changed the problem class (e.g. LP to MILP)
-    if unset
-        m.solver = JuMP.UnsetSolver()
-        if traits.int
-            m.internalModelLoaded = false
-        end
-    end
-
-    # don't keep relaxed model in memory
-    relaxation && (m.internalModelLoaded = false)
-
     # Return the solve status
     stat
 end

--- a/src/JuMPfunctions.jl
+++ b/src/JuMPfunctions.jl
@@ -41,7 +41,7 @@ function jumpsolve(m::JuMP.Model; suppress_warnings=false,
         unset = m.solver == JuMP.UnsetSolver()
 
         # Analyze the problems traits to determine what solvers we can use
-        traits = JuMP.ProblemTraits(m, relaxation)
+        traits = JuMP.ProblemTraits(m, relaxation=relaxation)
 
         # Build the MathProgBase model from the JuMP model
         JuMP.build(m, traits=traits, suppress_warnings=suppress_warnings, relaxation=relaxation)

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -437,8 +437,9 @@ control the solution process.
     constraints) leading to an increase in the solve time of individual subproblems.
     Defaults to `0` (never run).
  * `print_level::Int`:
-     0 - off: nothing logged to screen (still written to log file if specified).
-     1 - on: solve iterations written to screen.
+     0 - off: nothing logged.
+     1 - on: solve iterations logged.
+     2 - verbose: detailed timing information is also logged.
      Defaults to `1`
  * `log_file::String`:
     Relative filename to write the log to disk. Defaults to `""` (no log written)
@@ -526,7 +527,7 @@ function JuMP.solve(m::SDDPModel;
             rethrow(ex)
         end
     end
-    print(printfooter, settings, m, status, TIMER)
+    print(printfooter, settings, m, settings, status, TIMER)
     # print(print_timer, settings)
     status
 end

--- a/src/print.jl
+++ b/src/print.jl
@@ -6,9 +6,9 @@
 
 function printheader{T}(io::IO, m::SDDPModel{T}, solve_type)
     n = length(m.stages)
-    println(io, """-------------------------------------------------------------------------------
+    println(io, """--------------------------------------------------------------------------------
                           SDDP Solver. © Oscar Dowson, 2017.
-    -------------------------------------------------------------------------------""")
+    --------------------------------------------------------------------------------""")
     println(io, """    Solver:
             $(solve_type)
         Model:
@@ -16,18 +16,20 @@ function printheader{T}(io::IO, m::SDDPModel{T}, solve_type)
             States:         $(nstates(getsubproblem(m, 1, 1)))
             Subproblems:    $(sum(length(subproblems(s)) for s in stages(m)))
             Value Function: $(summarise(T))
-    -------------------------------------------------------------------------------""")
+    --------------------------------------------------------------------------------""")
     println(io, "              Objective              |  Cut  Passes    Simulations   Total    ")
     println(io, "     Simulation       Bound   % Gap  |   #     Time     #    Time    Time     ")
-    println(io, "-------------------------------------------------------------------------------")
+    println(io, "--------------------------------------------------------------------------------")
 end
 
-function printfooter(io::IO, m::SDDPModel, status)
-    println(io, "-------------------------------------------------------------------------------")
-    println(io, """    Statistics:
+function printfooter(io::IO, m::SDDPModel, status, timer)
+    println(io, "--------------------------------------------------------------------------------")
+    print_timer(io, timer, title="Timing statistics")
+    print(io, "\n")
+    println(io, """    Other Statistics:
             Iterations:         $(m.log[end].iteration)
             Termination Status: $(status)
-    -------------------------------------------------------------------------------""")
+    ================================================================================""")
 end
 
 function Base.print(io::IO, l::SolutionLog, printmean::Bool=false, is_min=true)

--- a/src/print.jl
+++ b/src/print.jl
@@ -22,10 +22,12 @@ function printheader{T}(io::IO, m::SDDPModel{T}, solve_type)
     println(io, "--------------------------------------------------------------------------------")
 end
 
-function printfooter(io::IO, m::SDDPModel, status, timer)
+function printfooter(io::IO, m::SDDPModel, settings, status, timer)
     println(io, "--------------------------------------------------------------------------------")
-    print_timer(io, timer, title="Timing statistics")
-    print(io, "\n")
+    if settings.print_level > 1
+        print_timer(io, timer, title="Timing statistics")
+        print(io, "\n")
+    end
     println(io, """    Other Statistics:
             Iterations:         $(m.log[end].iteration)
             Termination Status: $(status)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -187,7 +187,9 @@ end
 hasnoises(sp::JuMP.Model) = length(ext(sp).noises) > 0
 
 function JuMPsolve{T<:IterationDirection}(::Type{T}, ::SDDPModel, sp::JuMP.Model)
-    @assert JuMP.solve(sp) == :Optimal
+    @timeit TIMER "JuMP.solve" begin
+        @assert JuMP.solve(sp) == :Optimal
+    end
 end
 
 function savemodel!(filename::String, m::SDDPModel)

--- a/src/valuefunctions.jl
+++ b/src/valuefunctions.jl
@@ -79,13 +79,15 @@ function modifyvaluefunction!{V<:DefaultValueFunction}(m::SDDPModel{V}, settings
     for i in I
         m.storage.probability[i] *= getstage(m, ex.stage+1).transitionprobabilities[ex.markovstate, m.storage.markov[i]]
     end
-    modifyprobability!(ex.riskmeasure,
-        view(m.storage.modifiedprobability.data, I),
-        m.storage.probability.data[I],
-        m.storage.objective.data[I],
-        m,
-        sp
-    )
+    @timeit TIMER "risk measure" begin
+        modifyprobability!(ex.riskmeasure,
+            view(m.storage.modifiedprobability.data, I),
+            m.storage.probability.data[I],
+            m.storage.objective.data[I],
+            m,
+            sp
+        )
+    end
     cut = constructcut(m, sp)
 
     if writecuts && settings.cut_output_file != ""


### PR DESCRIPTION
Closes https://github.com/odow/SDDP.jl/issues/27

 - [ ] Needs docs.

Produces output like
```
─────────────────────────────────────────────────────────────────────────────
      Timing statistics              Time                   Allocations
                             ──────────────────────   ───────────────────────
      Tot / % measured:          78.0ms / 88.7%           3.03MiB / 100%

Section              ncalls     time   %tot     avg     alloc   %tot      avg
─────────────────────────────────────────────────────────────────────────────
Solve                     1   69.1ms   100%  69.1ms   3.02MiB  100%   3.02MiB
  Iteration Phase        30   59.8ms  86.5%  1.99ms   2.92MiB  96.7%   100KiB
    Backward Pass        30   44.1ms  63.8%  1.47ms   2.29MiB  75.7%  78.1KiB
      JuMP.solve        330   31.9ms  46.1%  96.6µs   1.00MiB  33.2%  3.11KiB
      Cut addition      150   3.10ms  4.49%  20.7µs    385KiB  12.4%  2.57KiB
    Forward Pass         30   15.6ms  22.5%   518µs    643KiB  20.8%  21.4KiB
      JuMP.solve        120   12.3ms  17.8%   103µs    375KiB  12.1%  3.12KiB
─────────────────────────────────────────────────────────────────────────────

```