### PR TITLE
Improve speed of writing cuts to file

### DIFF
--- a/src/JuMPfunctions.jl
+++ b/src/JuMPfunctions.jl
@@ -62,42 +62,28 @@ function jumpsolve(m::JuMP.Model; suppress_warnings=false,
         numRows, numCols = length(m.linconstr), m.numCols
         m.objBound = NaN
         m.objVal = NaN
-        if length(m.colVal) != numCols
-            m.colVal = fill(NaN, numCols)
-        else
-            m.colVal .= NaN
-        end
-        if length(m.linconstrDuals) != numRows
-            m.linconstrDuals = fill(NaN, numRows)
-        else
-            m.linconstrDuals .= NaN
-        end
-        if length(m.redCosts) != numCols
-            m.redCosts = fill(NaN, numCols)
-        else
-            m.redCosts .= NaN
-        end
-        # m.linconstrDuals = Array{Float64}(0)
+        m.colVal = fill(NaN, numCols)
+        m.linconstrDuals = Array{Float64}(0)
 
         discrete = !relaxation && (traits.int || traits.sos)
         if stat == :Optimal
             # If we think dual information might be available, try to get it
             # If not, return an array of the correct length
             if discrete
-                # m.redCosts = fill(NaN, numCols)
-                # m.linconstrDuals = fill(NaN, numRows)
+                m.redCosts = fill(NaN, numCols)
+                m.linconstrDuals = fill(NaN, numRows)
             else
                 if !traits.conic
-                    m.redCosts .= try
+                    m.redCosts = try
                         JuMP.MathProgBase.getreducedcosts(m.internalModel)[1:numCols]
                     catch
-                        # fill(NaN, numCols)
+                        fill(NaN, numCols)
                     end
 
-                    m.linconstrDuals .= try
+                    m.linconstrDuals = try
                         JuMP.MathProgBase.getconstrduals(m.internalModel)[1:numRows]
                     catch
-                        # fill(NaN, numRows)
+                        fill(NaN, numRows)
                     end
                 elseif !traits.qp && !traits.qc
                     fillConicDuals(m)
@@ -112,22 +98,22 @@ function jumpsolve(m::JuMP.Model; suppress_warnings=false,
             # if the exist.
             if traits.lin
                 if stat == :Infeasible
-                    m.linconstrDuals .= try
+                    m.linconstrDuals = try
                         infray = JuMP.MathProgBase.getinfeasibilityray(m.internalModel)
                         @assert length(infray) == numRows
                         infray
                     catch
                         suppress_warnings || warn("Infeasibility ray (Farkas proof) not available")
-                        # fill(NaN, numRows)
+                        fill(NaN, numRows)
                     end
                 elseif stat == :Unbounded
-                    m.colVal .= try
+                    m.colVal = try
                         unbdray = JuMP.MathProgBase.getunboundedray(m.internalModel)
                         @assert length(unbdray) == numCols
                         unbdray
                     catch
                         suppress_warnings || warn("Unbounded ray not available")
-                        # fill(NaN, numCols)
+                        fill(NaN, numCols)
                     end
                 end
             end
@@ -160,7 +146,7 @@ function jumpsolve(m::JuMP.Model; suppress_warnings=false,
                 end
                 # Don't corrupt the answers if one of the above two calls fails
                 m.objVal = objVal
-                m.colVal .= colVal
+                m.colVal = colVal
             end
         end
 

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -492,13 +492,14 @@ function JuMP.solve(m::SDDPModel;
     )
     reset_timer!(TIMER)
 
-    f = if cut_output_file != ""
+    cut_output_file_handle = if cut_output_file != ""
         open(cut_output_file, "w")
     else
         ff = IOStream("")
         close(ff)
         ff
     end
+
     settings = Settings(
         max_iterations,
         time_limit,
@@ -508,14 +509,8 @@ function JuMP.solve(m::SDDPModel;
         print_level,
         log_file,
         reduce_memory_footprint,
-        f
+        cut_output_file_handle
     )
-
-    # if cut_output_file != ""
-        # clear it
-        # open(cut_output_file, "w") do file
-        # end
-    # end
 
     print(printheader, settings, m, solve_type)
     status = :solving
@@ -531,10 +526,9 @@ function JuMP.solve(m::SDDPModel;
             rethrow(ex)
         end
     finally
-        close(f)
+        close(cut_output_file_handle)
     end
     print(printfooter, settings, m, settings, status, TIMER)
-    # print(print_timer, settings)
     status
 end
 

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -491,7 +491,11 @@ function JuMP.solve(m::SDDPModel;
         cut_output_file::String      = ""
     )
     reset_timer!(TIMER)
-
+    f = if cut_output_file != ""
+        open(cut_output_file, "w")
+    else
+        IOStream("")
+    end
     settings = Settings(
         max_iterations,
         time_limit,
@@ -501,14 +505,14 @@ function JuMP.solve(m::SDDPModel;
         print_level,
         log_file,
         reduce_memory_footprint,
-        cut_output_file
+        f
     )
 
-    if cut_output_file != ""
+    # if cut_output_file != ""
         # clear it
-        open(cut_output_file, "w") do file
-        end
-    end
+        # open(cut_output_file, "w") do file
+        # end
+    # end
 
     print(printheader, settings, m, solve_type)
     status = :solving
@@ -523,6 +527,8 @@ function JuMP.solve(m::SDDPModel;
         else
             rethrow(ex)
         end
+    finally
+        close(f)
     end
     print(printfooter, settings, m, settings, status, TIMER)
     # print(print_timer, settings)

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -491,10 +491,13 @@ function JuMP.solve(m::SDDPModel;
         cut_output_file::String      = ""
     )
     reset_timer!(TIMER)
+
     f = if cut_output_file != ""
         open(cut_output_file, "w")
     else
-        IOStream("")
+        ff = IOStream("")
+        close(ff)
+        ff
     end
     settings = Settings(
         max_iterations,

--- a/src/solve_asyncronous.jl
+++ b/src/solve_asyncronous.jl
@@ -165,7 +165,7 @@ function JuMP.solve{T}(async::Asyncronous, m::SDDPModel{T}, settings::Settings=S
                             (cuts, objective_bound, simulation_objective) = remotecall_fetch(async_iteration!, p, typeof(m), settings, newcuts)
                         end
                         for cut in cuts
-                            if settings.cut_output_file != ""
+                            if isopen(settings.cut_output_file)
                                 writeaynccut!(settings.cut_output_file, cut)
                             end
                             addcut!(m, cut)
@@ -254,6 +254,6 @@ function storecut!{C}(m::SDDPModel{DefaultValueFunction{C}}, sp::JuMP.Model, cut
     push!(m.ext[:cuts], (ext(sp).stage, ext(sp).markovstate, cut))
 end
 
-function writeaynccut!(file::String, cut::Tuple{Int, Int, Cut})
+function writeaynccut!(file, cut::Tuple{Int, Int, Cut})
     writecut!(file, cut[3], cut[1], cut[2])
 end

--- a/src/typedefinitions.jl
+++ b/src/typedefinitions.jl
@@ -246,6 +246,6 @@ immutable Settings
     print_level::Int
     log_file::String
     reduce_memory_footprint::Bool
-    cut_output_file::String
+    cut_output_file::IOStream
 end
-Settings() = Settings(0,600.0, MonteCarloSimulation(), BoundConvergence(), 0,0,"", false, "")
+Settings() = Settings(0,600.0, MonteCarloSimulation(), BoundConvergence(), 0,0,"", false, IOStream("Cuts"))

--- a/src/valuefunctions.jl
+++ b/src/valuefunctions.jl
@@ -41,13 +41,17 @@ end
 
 function writecut!(filename::String, cut::Cut, stage::Int, markovstate::Int)
     open(filename, "a") do file
-        write(file, "$(stage), $(markovstate), $(cut.intercept)")
-        for pi in cut.coefficients
-            write(file, ",$(pi)")
-        end
-        write(file, "\n")
+        writecut!(file, cut, stage, markovstate)
     end
 end
+function writecut!(io::IO, cut::Cut, stage::Int, markovstate::Int)
+    write(io, stage, ",", markovstate, ",", cut.intercept)
+    for pi in cut.coefficients
+        write(io, ",", pi)
+    end
+    write(io, "\n")
+end
+
 
 """
     loadcuts!(m::SDDPModel, filename::String)
@@ -105,7 +109,9 @@ function modifyvaluefunction!{V<:DefaultValueFunction}(m::SDDPModel{V}, settings
     cut = constructcut(m, sp)
 
     if writecuts && settings.cut_output_file != ""
-        writecut!(settings.cut_output_file, cut, ex.stage, ex.markovstate)
+        @timeit TIMER "cut to file" begin
+            writecut!(settings.cut_output_file, cut, ex.stage, ex.markovstate)
+        end
     end
 
     storecut!(vf.cutmanager, m, sp, cut)

--- a/src/valuefunctions.jl
+++ b/src/valuefunctions.jl
@@ -45,9 +45,9 @@ function writecut!(filename::String, cut::Cut, stage::Int, markovstate::Int)
     end
 end
 function writecut!(io::IO, cut::Cut, stage::Int, markovstate::Int)
-    write(io, stage, ",", markovstate, ",", cut.intercept)
+    write(io, string(stage), ",", string(markovstate), ",", string(cut.intercept))
     for pi in cut.coefficients
-        write(io, ",", pi)
+        write(io, ",", string(pi))
     end
     write(io, "\n")
 end

--- a/src/valuefunctions.jl
+++ b/src/valuefunctions.jl
@@ -108,7 +108,7 @@ function modifyvaluefunction!{V<:DefaultValueFunction}(m::SDDPModel{V}, settings
     end
     cut = constructcut(m, sp)
 
-    if writecuts && settings.cut_output_file != ""
+    if writecuts && isopen(settings.cut_output_file)
         @timeit TIMER "cut to file" begin
             writecut!(settings.cut_output_file, cut, ex.stage, ex.markovstate)
         end


### PR DESCRIPTION
Profiling revealed this was a significant (~15%) contributor to the runtime of the POWDER model. This fix reduces that to ~<0.5%.