### PR TITLE
Sampling Oracles

### DIFF
--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -219,7 +219,8 @@ function forwardpass!(m::SDDPModel, settings::Settings, solutionstore=nothing)
 
         # choose and set RHS noise
         if hasnoises(sp)
-            (noiseidx, noise) = samplenoise(sp, solutionstore)
+            noise = samplenoise(settings.oracle, sp, solutionstore)
+            noiseidx = 0
             setnoise!(sp, noise)
         end
         # solve subproblem
@@ -281,7 +282,6 @@ function iteration!(m::SDDPModel, settings::Settings)
         end
     end
     return objective_bound, time_backwards, simulation_objective, time_forwards
-
 end
 
 function rebuild!(m::SDDPModel)
@@ -434,6 +434,8 @@ control the solution process.
     Defaults to `false`.
  * `cut_output_file::String`:
     Relative filename to write discovered cuts to disk. Defaults to `""` (no cuts written)
+ * `oracle::SamplingOracle`
+    Scenario sampling method. Defaults to `DefaultSamplingOracle()`.
 
 # Returns
  * `status::Symbol`:
@@ -470,7 +472,8 @@ function JuMP.solve(m::SDDPModel;
         # this reduces memory but you shouldn't use it if you want to save the
         # sddp model since it throws away some information
         reduce_memory_footprint      = false,
-        cut_output_file::String      = ""
+        cut_output_file::String      = "",
+        oracle::SamplingOracle       = DefaultSamplingOracle()
     )
     reset_timer!(TIMER)
 
@@ -492,7 +495,8 @@ function JuMP.solve(m::SDDPModel;
         log_file,
         reduce_memory_footprint,
         cut_output_file_handle,
-        isa(solve_type, Asyncronous)
+        isa(solve_type, Asyncronous),
+        oracle
     )
 
     print(printheader, settings, m, solve_type)

--- a/src/noises.jl
+++ b/src/noises.jl
@@ -19,8 +19,8 @@ function samplenoise(sp::JuMP.Model)
 end
 samplenoise(sp::JuMP.Model, solutionstore::Void) = samplenoise(sp)
 function samplenoise(sp::JuMP.Model, solutionstore::Dict{Symbol, Any})
-    if length(solutionstore[:noise])>=ext(sp).stage
-        idx = solutionstore[:noise][ext(sp).stage]
+    if length(solutionstore[:noiseidx])>=ext(sp).stage
+        idx = solutionstore[:noiseidx][ext(sp).stage]
         return idx, ext(sp).noises[idx]
     else
         return samplenoise(sp)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -7,7 +7,7 @@
 function newsolutionstore(X::Vector{Symbol})
     d = Dict(
         :markov         => Int[],
-        :noise       => Int[],
+        :noiseidx       => Int[],
         :obj            => Float64[],
         :stageobjective => Float64[]
     )
@@ -27,7 +27,7 @@ function storekey!(::Type{Val{:markov}}, store, markov::Int, noiseidx::Int, sp::
     end
 end
 
-function storekey!(::Type{Val{:noise}}, store, markov::Int, noiseidx::Int, sp::JuMP.Model, t::Int)
+function storekey!(::Type{Val{:noiseidx}}, store, markov::Int, noiseidx::Int, sp::JuMP.Model, t::Int)
     if length(store) < t
         push!(store, noiseidx)
     else
@@ -82,7 +82,7 @@ function simulate(m::SDDPModel,
     store = newsolutionstore(variables)
     for t in 1:length(m.stages)
         push!(store[:markov], markovstates[t])
-        push!(store[:noise], noises[t])
+        push!(store[:noiseidx], noises[t])
     end
     obj = forwardpass!(m, Settings(), store)
     store[:objective] = obj
@@ -103,7 +103,7 @@ to the variables specified in the function call, other special keys are:
  - `:stageobjective` - costs incurred during the stage (not future)
  - `:obj`            - objective of the stage including future cost
  - `:markov`         - index of markov state visited
- - `:noise`          - index of noise visited
+ - `:noiseidx`       - index of noise visited
  - `:objective`      - Total objective of simulation
 
 All values can be accessed as follows

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -156,7 +156,7 @@ end
 samplesubproblem(stage::Stage, last_markov_state::Int, solutionstore::Void) = samplesubproblem(stage, last_markov_state)
 
 function samplesubproblem(stage::Stage, last_markov_state, solutionstore::Dict{Symbol, Any})
-    if length(solutionstore[:noise]) >= stage.t
+    if length(solutionstore[:noiseidx]) >= stage.t
         idx = solutionstore[:markov][stage.t]
         return idx, getsubproblem(stage, idx)
     else


### PR DESCRIPTION
An implementation of Sampling Oracles as suggested in #80, as well as renaming the `:noise` key to `:noiseidx` as suggested in #84.

I apologize for the delay. I wrote down most of the implementation a while ago, but I decided to wait some time before testing to do it with a clear mind. I ran into some minor issues, but I believe the current version should work. I tested it with [simplified_hydrothermal_dispatch.jl](https://github.com/odow/SDDP.jl/blob/master/examples/HydroValleys/simplified_hydrothermal_dispatch.jl).