### PR TITLE
Refactor price interpolation methods

### DIFF
--- a/examples/PriceInterpolation/newsvendor.jl
+++ b/examples/PriceInterpolation/newsvendor.jl
@@ -33,7 +33,7 @@ function newsvendor_example(DISCRETIZATION = 1)
     MAX_PRICE     = 2.25
     NOISES        = DiscreteDistribution([-0.25, -0.125, 0.125, 0.25])
 
-    function pricedynamics(price, noise, stage, markov)
+    function pricedynamics(price, noise)
         clamp(price + noise, MIN_PRICE, MAX_PRICE)
     end
 

--- a/examples/PriceInterpolation/perishablewidgets.jl
+++ b/examples/PriceInterpolation/perishablewidgets.jl
@@ -117,7 +117,7 @@ m = SDDPModel(
                                 add the input, but don't reference it. It won't
                                 matter.
                             ==#
-                            dynamics = (price, noise, t, i) -> begin
+                            dynamics = (price, noise) -> begin
                                 reversion_rate = 0.05
                                 process_mean = 6.0
                                 lower = 3.0

--- a/examples/PriceInterpolation/riverchain.jl
+++ b/examples/PriceInterpolation/riverchain.jl
@@ -57,16 +57,16 @@ function priceprocess(USE_AR1)
     end
 
     if USE_AR1
-        return DynamicPriceInterpolation(
-            dynamics       = ar1price,
+        return (t,i) -> DynamicPriceInterpolation(
+            dynamics       = (p,w) -> ar1price(p, w, t, i),
             initial_price  = pbar,
             min_price      = minprice,
             max_price      = maxprice,
             noise          = NOISES
         )
     else
-        return DynamicPriceInterpolation(
-            dynamics       = ar2price,
+        return (t,i) -> DynamicPriceInterpolation(
+            dynamics       = (p,w) -> ar2price(p, w, t, i),
             initial_price  = (pbar, pbar),
             min_price      = (minprice, minprice),
             max_price      = (maxprice, maxprice),
@@ -76,13 +76,12 @@ function priceprocess(USE_AR1)
 end
 
 function buildmodel(USE_AR1, valley_chain)
-    valuefunction = priceprocess(USE_AR1)
     return SDDPModel(
                 sense           = :Min,
                 stages          = 12,
                 objective_bound = 50_000.0,
                 solver          = ClpSolver(),
-                value_function   = valuefunction
+                value_function   = priceprocess(USE_AR1)
                                         ) do sp, stage
         N = length(valley_chain)
         turbine(i) = valley_chain[i].turbine

--- a/examples/PriceInterpolation/simple_contracting.jl
+++ b/examples/PriceInterpolation/simple_contracting.jl
@@ -68,8 +68,8 @@ function contracting_example(DISCRETIZATION = 1)
     end
 
     value_function = if DISCRETIZATION == 1
-        DynamicPriceInterpolation(
-            dynamics       = pricedynamics,
+        (t,i) -> DynamicPriceInterpolation(
+            dynamics       = (p,w) -> pricedynamics(p,w,t,i),
             initial_price  = INITIAL_PRICE,
             min_price      = MIN_PRICE,
             max_price      = MAX_PRICE,
@@ -78,8 +78,8 @@ function contracting_example(DISCRETIZATION = 1)
             lipschitz_constant = 75.0
         )
     else
-        StaticPriceInterpolation(
-            dynamics       = pricedynamics,
+        (t,i) -> StaticPriceInterpolation(
+            dynamics       = (p,w) -> pricedynamics(p,w,t,i),
             initial_price  = INITIAL_PRICE,
             rib_locations  =  collect(linspace(MIN_PRICE, MAX_PRICE, DISCRETIZATION)),
             noise          = NOISES,

--- a/examples/PriceInterpolation/widget_producer.jl
+++ b/examples/PriceInterpolation/widget_producer.jl
@@ -39,16 +39,16 @@ function widget_producer_example(DISCRETIZATION = 1)
     end
 
     value_function = if DISCRETIZATION == 1
-        DynamicPriceInterpolation(
-            dynamics       = pricedynamics,
+        (t,i) -> DynamicPriceInterpolation(
+            dynamics       = (p,w) -> pricedynamics(p,w,t,i),
             initial_price  = P₀,
             min_price      = Pₗ,
             max_price      = Pᵤ,
             noise          = Φ
         )
     else
-        StaticPriceInterpolation(
-            dynamics       = pricedynamics,
+        (t,i) -> StaticPriceInterpolation(
+            dynamics       = (p,w) -> pricedynamics(p,w,t,i),
             initial_price  = P₀,
             # we need to ensure the ribs are not binding on the edge of the
             # price domain because sometimes the duals can be weird / numeric

--- a/src/price_interpolation/dynamic_price_interpolation.jl
+++ b/src/price_interpolation/dynamic_price_interpolation.jl
@@ -13,13 +13,11 @@ plane method for multistage stochastic programming problems with stagewise
 dependent price uncertainty. Optimization Online.
 
 ### Keyword arguments
- - `dynamics`: a function that takes four arguments
+ - `dynamics`: a function that takes two arguments
         1. `price`: a Float64 (if uni-variate) or NTuple{N,Float64} if multi-variate
             that gives the price in the previous stage.
         2. `noise`: a single `NoiseRealization` of the price noise observed at
             the start of the stage.
-        3. `t::Int`: the index of the stage of the problem t=1, 2, ..., T.
-        4. `i::Int`: the markov state index of the problem i=1, 2, ..., S(t).
         The function should return a Float64 (if uni-variate) or NTuple{N,Float64}
         if multi-variate that gives the price for the current stage.
  - `initial_price`: a Float64 (if uni-variate) or NTuple{N,Float64} if multi-variate
@@ -38,7 +36,7 @@ dependent price uncertainty. Optimization Online.
 A uni-variate price process:
 
     DynamicPriceInterpolation(
-        dynamics = (price, noise, t, i) -> begin
+        dynamics = (price, noise) -> begin
                 return price + noise - t
             end,
         initial_price = 50.0
@@ -51,7 +49,7 @@ A uni-variate price process:
 A multi-variate price process:
 
     DynamicPriceInterpolation(
-        dynamics = (price, noise, t, i) -> begin
+        dynamics = (price, noise) -> begin
                 return (noise * price[1], noise * price[2] - noise)
             end,
         initial_price = (50.0, 50.0),
@@ -62,7 +60,7 @@ A multi-variate price process:
     )
 """
 function DynamicPriceInterpolation(;
-    dynamics = (p,w,t,i)->p,
+    dynamics = (p,w)->p,
     initial_price = 0.0,
     min_price = 0.0,
     max_price = 1.0,

--- a/src/price_interpolation/price_interpolation.jl
+++ b/src/price_interpolation/price_interpolation.jl
@@ -89,7 +89,7 @@ end
 
 function setobjective!(sp::JuMP.Model, price, noise)
     vf = valueoracle(sp)
-    p = vf.dynamics(price, noise, ext(sp).stage, ext(sp).markovstate)
+    p = vf.dynamics(price, noise)
     vf.location = p
     # stage objective obj
     stageobj = vf.objective(p)

--- a/src/price_interpolation/static_price_interpolation.jl
+++ b/src/price_interpolation/static_price_interpolation.jl
@@ -15,12 +15,10 @@ Power Systems Computation Conference : Proceedings P. 1328. Trondheim: Executi
 Board of the 13th Power Systems Computation Conference, 1999.
 
 ### Keyword arguments
- - `dynamics`: a function that takes four arguments
+ - `dynamics`: a function that takes two arguments
         1. `price`: a Float64 that gives the price in the previous stage.
         2. `noise`: a single `NoiseRealization` of the price noise observed at
             the start of the stage.
-        3. `t::Int`: the index of the stage of the problem t=1, 2, ..., T.
-        4. `i::Int`: the markov state index of the problem i=1, 2, ..., S(t).
         The function should return a Float64 of the price for the current stage.
  - `initial_price`: a Float64 for the an initial value for each dimension of the price states.
  - `rib_locations`: an `AbstractVector{Float64}` giving the points at which to
@@ -31,7 +29,7 @@ Board of the 13th Power Systems Computation Conference, 1999.
 # Example
 
     StaticPriceInterpolation(
-        dynamics = (price, noise, t, i) -> begin
+        dynamics = (price, noise) -> begin
                 return price + noise - t
             end,
         initial_price = 50.0
@@ -41,7 +39,7 @@ Board of the 13th Power Systems Computation Conference, 1999.
 """
 function StaticPriceInterpolation(;
                cut_oracle = DefaultCutOracle(),
-                 dynamics = (p,w,t,i)->p,
+                 dynamics = (p,w)->p,
             initial_price::T = 0.0,
             rib_locations::AbstractVector{T} = [0.0, 1.0],
                     noise = DiscreteDistribution([0.0])


### PR DESCRIPTION
I'm going to ram this through before anyone actually starts to use the feature. If you want stage-dependent dynamics etc, you should use the functional approach
```julia
function buildvaluefunction(stage::Int, markov_state::Int)
    DynamicValueFunction(
        dynamics = (price, noise) -> price + state * noise,
        # ...
    )
end
```

Closes #95 