### PR TITLE
Deprecate NestedAVaR -> EAVaR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+#### 6/March/2018
+- Deprecated `NestedAVaR` in favour of `EAVaR` (#106)
+
 #### 7/February/2018
 - Added price interpolation value functions (#86)
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -22,9 +22,9 @@ AbstractRiskMeasure
 modifyprobability!
 AVaR
 ConvexCombination
+EAVaR
 Expectation
 DRO
-NestedAVaR
 WorstCase
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -128,7 +128,7 @@ important ones here.
     measures. There must be one element for every stage. For example:
 
 ```julia
-risk_measure = [ NestedAVaR(lambda=0.5, beta=0.25), Expectation() ]
+risk_measure = [ EAVaR(lambda=0.5, beta=0.25), Expectation() ]
 ```
 
    will apply the `i`'th element of `risk_measure` to every Markov state in the
@@ -141,7 +141,7 @@ risk_measure = [
 # Stage 1 Markov 1 # Stage 1 Markov 2 #
    [ Expectation(), Expectation() ],
    # ------- Stage 2 Markov 1 ------- ## ------- Stage 2 Markov 2 ------- #
-   [ NestedAVaR(lambda=0.5, beta=0.25), NestedAVaR(lambda=0.25, beta=0.3) ]
+   [ EAVaR(lambda=0.5, beta=0.25), EAVaR(lambda=0.25, beta=0.3) ]
    ]
 ```
     Like the objective bound, another option is to pass a function that takes
@@ -153,9 +153,9 @@ function stagedependentrisk(stage, markov_state)
         return Expectation()
     else
         if markov_state == 1
-            return NestedAVaR(lambda=0.5, beta=0.25)
+            return EAVaR(lambda=0.5, beta=0.25)
         else
-            return NestedAVaR(lambda=0.25, beta=0.3)
+            return EAVaR(lambda=0.25, beta=0.3)
         end
     end
 end
@@ -167,7 +167,7 @@ risk_measure = stagedependentrisk
    associated with it (as it has no children), we still have to specify a risk
    measure. This is necessary to simplify the implementation of the algorithm.
 
-   For more help see [`NestedAVaR`](@ref) or [`Expectation`](@ref).
+   For more help see [`EAVaR`](@ref) or [`Expectation`](@ref).
 
  * `markov_transition`: define the transition probabilties of the stage graph.
    If a single array is given, it is assumed that there is an equal number of
@@ -399,7 +399,7 @@ m = SDDPModel(
          risk_measure = [
                         Expectation(),
                         Expectation(),
-                        NestedAVaR(lambda = 0.5, beta=0.5),
+                        EAVaR(lambda = 0.5, beta=0.5),
                         Expectation()
                     ]
                             ) do sp, t, i

--- a/examples/AssetManagement/asset_management_stagewise.jl
+++ b/examples/AssetManagement/asset_management_stagewise.jl
@@ -30,7 +30,7 @@ m = SDDPModel(
         [0.5 0.5; 0.5 0.5],
         [0.5 0.5; 0.5 0.5]
     ],
-    risk_measure = [Expectation(), Expectation(), NestedAVaR(lambda = 0.5, beta=0.5), Expectation()]
+    risk_measure = [Expectation(), Expectation(), EAVaR(lambda = 0.5, beta=0.5), Expectation()]
                             ) do sp, t, i
     @state(sp, xs >= 0, xsbar==0)
     @state(sp, xb >= 0, xbbar==0)

--- a/examples/HydroValleys/hydro_valley_tests.jl
+++ b/examples/HydroValleys/hydro_valley_tests.jl
@@ -32,7 +32,7 @@ SDDP.solve(markov_stagewise_model, max_iterations=10, print_level=0)
 @test isapprox(getbound(markov_stagewise_model), 855.0, atol=1e-3)
 
 # risk averse stagewise inflows and markov prices
-riskaverse_model = hydrovalleymodel(riskmeasure = NestedAVaR(lambda=0.5, beta=0.66))
+riskaverse_model = hydrovalleymodel(riskmeasure = EAVaR(lambda=0.5, beta=0.66))
 SDDP.solve(riskaverse_model,
     max_iterations = 10,
     print_level = 0
@@ -42,7 +42,7 @@ SDDP.solve(riskaverse_model,
 
 # stagewise inflows and markov prices
 worst_case_model = hydrovalleymodel(
-    riskmeasure = NestedAVaR(lambda=0.5, beta=0.0), sense=:Min)
+    riskmeasure = EAVaR(lambda=0.5, beta=0.0), sense=:Min)
 SDDP.solve(worst_case_model,
     max_iterations = 10,
     simulation = MonteCarloSimulation(

--- a/examples/Newsvendor/async_newsvendor.jl
+++ b/examples/Newsvendor/async_newsvendor.jl
@@ -83,7 +83,7 @@ function createmodel(risk_measure)
     end
 end
 
-m = createmodel(NestedAVaR(beta   = 0.6, lambda = 0.5))
+m = createmodel(EAVaR(beta   = 0.6, lambda = 0.5))
 
 
 @test_throws Exception SDDP.solve(m, max_iterations=30, solve_type=Asyncronous(slaves=[2]))

--- a/examples/Newsvendor/newsvendor.jl
+++ b/examples/Newsvendor/newsvendor.jl
@@ -92,7 +92,7 @@ news1 = newsvendormodel()
 ) == :bound_convergence
 @test isapprox(getbound(news1), -97.9, atol=1e-3)
 
-news2 = newsvendormodel(riskmeasure=NestedAVaR(beta=0.6,lambda=0.5))
+news2 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
 @test SDDP.solve(news2,
     max_iterations = 50,
     print_level = 0,
@@ -123,7 +123,7 @@ historical_results2 = simulate(news2, [:buy, :sell];
 
 
 # Build and solve a model
-news3 = newsvendormodel(riskmeasure=NestedAVaR(beta=0.6,lambda=0.5))
+news3 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
 cuts_file_name = "newsvendor_cuts.csv"
 @test SDDP.solve(news3,
     max_iterations = 30,
@@ -135,7 +135,7 @@ results3 = simulate(news3, 500)
 @test isapprox(mean(r[:objective] for r in results3), -97.9, atol=0.1)
 
 # Build a completely new model and load old cuts
-news4 = newsvendormodel(riskmeasure=NestedAVaR(beta=0.6,lambda=0.5))
+news4 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
 loadcuts!(news4, cuts_file_name)
 
 # Simulating the new model gives the same results as before
@@ -144,7 +144,7 @@ results4 = simulate(news4, 500)
 @test isapprox(mean(r[:objective] for r in results4), -97.9, atol=0.1)
 
 # Build a completely new model with a different cut manager
-news5 = newsvendormodel(riskmeasure=NestedAVaR(beta=0.6,lambda=0.5), oracle=DematosCutOracle())
+news5 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5), oracle=DematosCutOracle())
 # Even dominated cuts are added and kept
 loadcuts!(news5, cuts_file_name)
 

--- a/examples/PriceInterpolation/perishablewidgets.jl
+++ b/examples/PriceInterpolation/perishablewidgets.jl
@@ -93,7 +93,7 @@ m = SDDPModel(
         of the tail we are worried about. Therefore, decreasing values of beta
         are more risk averse.
     ==#
-    risk_measure      = NestedAVaR(lambda=0.5, beta=0.25),
+    risk_measure      = EAVaR(lambda=0.5, beta=0.25),
     # price risk magic
     value_function    = StaticPriceInterpolation(
                             #==

--- a/examples/PriceInterpolation/simple_contracting.jl
+++ b/examples/PriceInterpolation/simple_contracting.jl
@@ -92,7 +92,7 @@ function contracting_example(DISCRETIZATION = 1)
         stages            = T,
         objective_bound   = 200.0,
         solver            = ClpSolver(),
-        risk_measure      = NestedAVaR(lambda=0.8, beta=0.5),
+        risk_measure      = EAVaR(lambda=0.8, beta=0.5),
         value_function    = value_function
                                             ) do sp, t
         @states(sp, begin

--- a/examples/PriceInterpolation/widget_producer.jl
+++ b/examples/PriceInterpolation/widget_producer.jl
@@ -64,7 +64,7 @@ function widget_producer_example(DISCRETIZATION = 1)
         stages            = T,
         objective_bound   = 50.0,
         solver            = ClpSolver(),
-        # risk_measure      = NestedAVaR(lambda=0.5, beta=0.25),
+        # risk_measure      = EAVaR(lambda=0.5, beta=0.25),
         value_function    = value_function
                                             ) do sp, t
         #=

--- a/examples/visualize_value_function.jl
+++ b/examples/visualize_value_function.jl
@@ -23,7 +23,7 @@ m = SDDPModel(
         [0.5 0.5; 0.5 0.5],
         [0.5 0.5; 0.5 0.5]
     ],
-    risk_measure = [Expectation(), Expectation(), NestedAVaR(lambda = 0.5, beta=0.5), Expectation()]
+    risk_measure = [Expectation(), Expectation(), EAVaR(lambda = 0.5, beta=0.5), Expectation()]
                             ) do sp, t, i
     @state(sp, xs >= 0, xsbar==0)
     @state(sp, xb >= 0, xbbar==0)

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -28,3 +28,4 @@ end
 @deprecate_macro noises rhsnoises
 @deprecate stageobjective! setstageobjective!
 @deprecate init! initializevaluefunction
+@deprecate NestedAVaR(;lambda=1.0,beta=1.0) EAVaR(;lambda=lambda,beta=beta)

--- a/src/risk_measures/AVaR.jl
+++ b/src/risk_measures/AVaR.jl
@@ -4,6 +4,8 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 
+export AVaR
+
 """
     AVaR(beta::Float64)
 

--- a/src/risk_measures/ConvexCombination.jl
+++ b/src/risk_measures/ConvexCombination.jl
@@ -6,6 +6,8 @@
 
 import Base: +, *
 
+export EAVaR
+
 """
     ConvexCombination( (weight::Float64, measure::AbstractRiskMeasure) ... )
 
@@ -50,7 +52,7 @@ function modifyprobability!(riskmeasure::ConvexCombination,
 end
 
 """
-    NestedAVaR(;lambda=1.0, beta=1.0)
+    EAVaR(;lambda=1.0, beta=1.0)
 
 # Description
 
@@ -70,7 +72,7 @@ Inreasing values of `lambda` are less risk averse (more weight on expecattion)
  of `beta` are less risk averse. If `beta=0`, then the AV@R component is the
  worst case risk measure.
 """
-function NestedAVaR(;lambda::Float64=1.0, beta::Float64=1.0)
+function EAVaR(;lambda::Float64=1.0, beta::Float64=1.0)
     if lambda > 1.0 || lambda < 0.0
         error("Lambda must be in the range [0, 1]. Increasing values of lambda are less risk averse. lambda=1 is identical to taking the expectation.")
     end

--- a/src/risk_measures/Expectation.jl
+++ b/src/risk_measures/Expectation.jl
@@ -4,6 +4,8 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 
+export Expectation
+
 """
     Expectation()
 

--- a/src/risk_measures/WorstCase.jl
+++ b/src/risk_measures/WorstCase.jl
@@ -4,6 +4,8 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 
+export WorstCase
+
 """
     WorstCase()
 

--- a/src/risk_measures/riskmeasures.jl
+++ b/src/risk_measures/riskmeasures.jl
@@ -4,8 +4,6 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #############################################################################
 
-export Expectation, AVaR, NestedAVaR, WorstCase
-
 """
     modifyprobability!(measure::AbstractRiskMeasure,
             riskadjusted_distribution,

--- a/test/riskmeasures.jl
+++ b/test/riskmeasures.jl
@@ -17,7 +17,7 @@ struct MyRiskMeasure <: SDDP.AbstractRiskMeasure end
         @test d.measures[2] == (0.3, b)
         @test d.measures[3] == (0.2, c)
 
-        aa = NestedAVaR(lambda=0.5, beta=0.25)
+        aa = EAVaR(lambda=0.5, beta=0.25)
         @test aa.measures[1] == (0.5, Expectation())
         @test aa.measures[2] == (0.5, AVaR(0.25))
     end
@@ -82,11 +82,11 @@ struct MyRiskMeasure <: SDDP.AbstractRiskMeasure end
 
 
     @testset "AV@R" begin
-        @test_throws Exception NestedAVaR(lambda=1.1)
-        @test_throws Exception NestedAVaR(lambda=-0.1)
-        @test_throws Exception NestedAVaR(beta=1.1)
-        @test_throws Exception NestedAVaR(beta=-0.1)
-        measure = NestedAVaR(lambda=0.25, beta=0.2)
+        @test_throws Exception EAVaR(lambda=1.1)
+        @test_throws Exception EAVaR(lambda=-0.1)
+        @test_throws Exception EAVaR(beta=1.1)
+        @test_throws Exception EAVaR(beta=-0.1)
+        measure = EAVaR(lambda=0.25, beta=0.2)
         m = SDDPModel(
             sense           = :Max,
             stages          = 2,
@@ -104,7 +104,7 @@ struct MyRiskMeasure <: SDDP.AbstractRiskMeasure end
         SDDP.modifyprobability!(measure, y, x, obj, m, SDDP.getsubproblem(m, 1, 1))
         @test isapprox(y, 0.25 * x + 0.75 * [1/2, 1/2, 0, 0], atol=1e-6)
 
-        measure = NestedAVaR(lambda=0.25, beta=0.2)
+        measure = EAVaR(lambda=0.25, beta=0.2)
         m = SDDPModel(
             sense           = :Min,
             stages          = 2,
@@ -122,7 +122,7 @@ struct MyRiskMeasure <: SDDP.AbstractRiskMeasure end
         SDDP.modifyprobability!(measure, y, x, obj, m, SDDP.getsubproblem(m, 1, 1))
         @test isapprox(y, 0.25 * x + 0.75 * [0, 0, 0, 1.0], atol=1e-6)
 
-        measure = NestedAVaR(lambda=0.5, beta=0.0)
+        measure = EAVaR(lambda=0.5, beta=0.0)
         m = SDDPModel(
             sense           = :Max,
             stages          = 2,
@@ -139,7 +139,7 @@ struct MyRiskMeasure <: SDDP.AbstractRiskMeasure end
         SDDP.modifyprobability!(measure, y, x, obj, m, SDDP.getsubproblem(m, 1, 1))
         @test isapprox(y, 0.5 * x + 0.5 * [1.0, 0, 0, 0], atol=1e-6)
 
-        measure = NestedAVaR(lambda=0.5, beta=0.0)
+        measure = EAVaR(lambda=0.5, beta=0.0)
         m = SDDPModel(
             sense           = :Max,
             stages          = 2,


### PR DESCRIPTION
I never liked the name and it wasn't informative. However, the new name is still a little uninformative, so we should really encourage people to write
```julia
λExpectation()+(1-λ)AVaR(β)
```
since without spaces, it is the same length as the original
```julia
NestedAVaR(lambda=λ,beta=β)
```
