### PR TITLE
Rename some stuff

### DIFF
--- a/docs/src/tutorial/01_first_steps.md
+++ b/docs/src/tutorial/01_first_steps.md
@@ -185,15 +185,13 @@ end
 ```
 
 To solve this problem, we use the [`solve`](@ref) method:
-
 ```julia
-status = solve(m; max_iterations=5)
+status = solve(m; iteration_limit=5)
 ```
-
-The return value `status` is a symbol describing why the SDDP algorithm
-terminated. In this case, the value is `:max_iterations`. We discuss other
-arguments to the [`solve`](@ref) method and other possible values for `status`
-in future sections of this manual.
+The argument `iteration_limit` is self-explanatory. The return value `status` is
+a symbol describing why the SDDP algorithm terminated. In this case, the value
+is `:iteration_limit`. We discuss other arguments to the [`solve`](@ref) method
+and other possible values for `status` in future sections of this manual.
 
 During the solve, the following log is printed to the screen.
 ```
@@ -219,7 +217,7 @@ During the solve, the following log is printed to the screen.
 -------------------------------------------------------------------------------
     Other Statistics:
         Iterations:         5
-        Termination Status: max_iterations
+        Termination Status: iteration_limit
 ===============================================================================
 ```
 

--- a/docs/src/tutorial/02_rhs_noise.md
+++ b/docs/src/tutorial/02_rhs_noise.md
@@ -184,7 +184,7 @@ only conducted 50 replications; however, the second time we conducted 100. This
 demonstrates the *sequential sampling* method at work.
 
 Finally, the termination status is now `:converged` instead of
-`:max_iterations`.
+`:iteration_limit`.
 
 ## Understanding the solution
 

--- a/docs/src/tutorial/02_rhs_noise.md
+++ b/docs/src/tutorial/02_rhs_noise.md
@@ -108,12 +108,12 @@ different components.
 ```julia
 status = solve(m,
     simulation = MonteCarloSimulation(
-        frequency   = 2,
-        confidence  = 0.95,
-        termination = true
-        min         = 50,
-        step        = 50,
-        max         = 100,
+        frequency  = 2,
+        confidence = 0.95,
+        terminate  = true
+        min        = 50,
+        step       = 50,
+        max        = 100,
     )
 )
 ```
@@ -122,8 +122,8 @@ First, the `frequency` argument specifies how often the  Monte Carlo simulation
 is conducted (iterations/simulation). For this example, we conduct a Monte Carlo
 simulation every two iterations. Second, the `confidence` specifies the level at
 which to conduct the confidence interval. In this example, we construct a 95%
-confidence interval. Third, the `termination` argument is a Boolean defining if
-we should terminate the method if the lower limit of the confidence interval is
+confidence interval. Third, the `terminate` argument is a Boolean defining if we
+should terminate the method if the lower limit of the confidence interval is
 less than the lower bound (upper limit and bound for maximization problems). The
 final three arguments implement the method of *sequential sampling*: `min` gives
 the minimum number of replications to conduct before the construction of a

--- a/docs/src/tutorial/05_risk.md
+++ b/docs/src/tutorial/05_risk.md
@@ -109,19 +109,19 @@ the literature. In addition to the termination methods discussed in previous
 tutorials, the user can also terminate the solve using the keys `[CRTL]+[C]`.
 
 In addition, to demonstrate that we cannot use Monte Carlo simulation to
-estimate the upper  bound of a risk-averse model, we perform a Monte Carlo
-simulation of the policy  every two iterations. If left unchecked, this solve
-will not terminate as we have set `termination=false`.
+estimate the upper bound of a risk-averse model, we perform a Monte Carlo
+simulation of the policy every two iterations. If left unchecked, this solve
+will not terminate as we have set `terminate=false`.
 
 ```julia
 status = solve(m,
     simulation = MonteCarloSimulation(
-        frequency   = 2,
-        confidence  = 0.95,
-        termination = false,
-        min         = 50,
-        step        = 50,
-        max         = 100,
+        frequency  = 2,
+        confidence = 0.95,
+        terminate  = false,
+        min        = 50,
+        step       = 50,
+        max        = 100,
     )
 )
 ```

--- a/docs/src/tutorial/06_cut_selection.md
+++ b/docs/src/tutorial/06_cut_selection.md
@@ -81,7 +81,7 @@ complicated (i.e. many variables and constraints) models.
 
 ```julia
 status = solve(m,
-    max_iterations          = 10,
+    iteration_limit         = 10,
     cut_selection_frequency = 5
 )
 ```

--- a/docs/src/tutorial/07_plotting.md
+++ b/docs/src/tutorial/07_plotting.md
@@ -48,7 +48,7 @@ end
 We're going to solve this for 20 iterations and then simulate 100 Monte Carlo
 realizations of the solution.
 ```julia
-status = solve(m, max_iterations = 20)
+status = solve(m, iteration_limit = 20)
 simulation_result = simulate(m,
     100,
     [:outgoing_volume, :thermal_generation, :hydro_generation, :hydro_spill]

--- a/docs/src/tutorial/08_odds_and_ends.md
+++ b/docs/src/tutorial/08_odds_and_ends.md
@@ -139,7 +139,7 @@ the `cut_output_file` to [`solve`](@ref):
 ```julia
 m = build_model()
 SDDP.solve(m
-    max_iterations  = 10,
+    iteration_limit = 10,
     cut_output_file = "cuts.csv"
 )
 ```
@@ -211,7 +211,7 @@ call. This produces a log like:
  ─────────────────────────────────────────────────────────────────────────────────
     Other Statistics:
         Iterations:         10
-        Termination Status: max_iterations
+        Termination Status: iteration_limit
 ===============================================================================
 ```
 

--- a/docs/src/tutorial/09_nonlinear.md
+++ b/docs/src/tutorial/09_nonlinear.md
@@ -77,7 +77,7 @@ end
 
 This problem can be solved just like any other SDDP model:
 ```julia
-status = solve(m, max_iterations = 10)
+status = solve(m, iteration_limit = 10)
 simulation_result = simulate(m, 1, [:inflow′])
 ```
 Then, we can check that the inflows do indeed follow a log auto-regressive

--- a/docs/src/tutorial/10_parallel.md
+++ b/docs/src/tutorial/10_parallel.md
@@ -95,8 +95,8 @@ We can solve this using SDDP.jl's asynchronous feature by passing an instance of
 [`Asynchronous`](@ref) to the `solve_type` keyword in [`solve`](@ref):
 ```julia
 status = solve(m,
-    max_iterations = 10,
-    solve_type     = Asynchronous()
+    iteration_limit = 10,
+    solve_type      = Asynchronous()
 )
 ```
 If you have multiple processes, SDDP.jl will detect this and choose asynchronous
@@ -132,7 +132,7 @@ The log is:
 -------------------------------------------------------------------------------
     Other Statistics:
         Iterations:         10
-        Termination Status: max_iterations
+        Termination Status: iteration_limit
 ===============================================================================
 ```
 Note that the order of the *Cut #* column is not sequential because they are

--- a/examples/Agriculture/mccardle_farm.jl
+++ b/examples/Agriculture/mccardle_farm.jl
@@ -137,7 +137,7 @@ end
 
 srand(111)
 m = mccardle_farm_model()
-solution = solve(m, max_iterations=20, print_level=0)
+solution = solve(m, iteration_limit=20, print_level=0)
 @test isapprox(getbound(m), 4074.1391, atol=1e-5)
 
 # results = simulate(m,  # Simulate the policy

--- a/examples/AssetManagement/asset_management.jl
+++ b/examples/AssetManagement/asset_management.jl
@@ -49,7 +49,7 @@ end
 
 srand(111)
 solve(m,
-    max_iterations = 25,
+    iteration_limit = 25,
     print_level    = 0
 )
 @test isapprox(getbound(m), 1.514, atol=1e-4)

--- a/examples/AssetManagement/asset_management_stagewise.jl
+++ b/examples/AssetManagement/asset_management_stagewise.jl
@@ -59,7 +59,7 @@ status = solve(m,
         min  = 100,
         step = 100,
         max  = 500,
-        termination = false
+        terminate = false
     ),
     bound_convergence = BoundConvergence(
         iterations = 5,

--- a/examples/AssetManagement/asset_management_stagewise.jl
+++ b/examples/AssetManagement/asset_management_stagewise.jl
@@ -53,7 +53,7 @@ end
 
 srand(111)
 status = solve(m,
-    max_iterations = 100,
+    iteration_limit = 100,
     simulation = MonteCarloSimulation(
         frequency = 5,
         min  = 100,

--- a/examples/BinaryProblems/airconditioning.jl
+++ b/examples/BinaryProblems/airconditioning.jl
@@ -51,5 +51,5 @@ end
 
 srand(1234)
 m = airconditioningmodel()
-solve(m, max_iterations=16, print_level=2)
+solve(m, iteration_limit=16, print_level=2)
 @test isapprox(getbound(m), 62_500.0)

--- a/examples/BinaryProblems/booking_management.jl
+++ b/examples/BinaryProblems/booking_management.jl
@@ -83,10 +83,10 @@ end
 
 srand(1234)
 m_1_2_5 = bookingmanagementmodel(1, 2, 5)
-@test solve(m_1_2_5, max_iterations = 10, print_level = 0) == :max_iterations
+@test solve(m_1_2_5, iteration_limit = 10, print_level = 0) == :iteration_limit
 @test isapprox(getbound(m_1_2_5), 7.25, atol=0.001)
 
 srand(1234)
 m_2_2_3 = bookingmanagementmodel(2, 2, 3)
-@test solve(m_2_2_3, max_iterations = 40, print_level = 0) == :max_iterations
+@test solve(m_2_2_3, iteration_limit = 40, print_level = 0) == :iteration_limit
 @test isapprox(getbound(m_2_2_3), 6.13, atol=0.001)

--- a/examples/BinaryProblems/vehicle_location.jl
+++ b/examples/BinaryProblems/vehicle_location.jl
@@ -93,7 +93,7 @@ function vehiclelocationmodel(nvehicles, baselocations, requestlocations)
 end
 
 ambulancemodel = vehiclelocationmodel(3, [0, 20, 40, 60, 80, 100], 0:2:100)
-@test solve(ambulancemodel, max_iterations=50, print_level=0) == :max_iterations
+@test solve(ambulancemodel, iteration_limit=50, print_level=0) == :iteration_limit
 @test isapprox(getbound(ambulancemodel), 1700.0, atol=5)
 # N = 100
 # results = simulate(m, N, [:dispatch, :q, :shift])

--- a/examples/FAST/hydro_thermal.jl
+++ b/examples/FAST/hydro_thermal.jl
@@ -31,7 +31,7 @@ m = SDDPModel(
     @stageobjective(sp, 5 * p)
 end
 
-status = solve(m, max_iterations = 10,
+status = solve(m, iteration_limit = 10,
 print_level = 0)
 
 @test getbound(m) == 10

--- a/examples/FAST/production_management_multiple_stages.jl
+++ b/examples/FAST/production_management_multiple_stages.jl
@@ -38,7 +38,7 @@ m = SDDPModel(
 
 end
 
-status = solve(m, max_iterations = 10,
+status = solve(m, iteration_limit = 10,
 print_level = 0)
 
 @test isapprox(getbound(m), -23.96, atol=1e-2)

--- a/examples/FAST/quickstart.jl
+++ b/examples/FAST/quickstart.jl
@@ -29,7 +29,7 @@ m = SDDPModel(
     end
 end
 
-status = solve(m, max_iterations = 3,
+status = solve(m, iteration_limit = 3,
 print_level = 0)
 
 @test getbound(m) == -2

--- a/examples/HydroValleys/hydro_valley_tests.jl
+++ b/examples/HydroValleys/hydro_valley_tests.jl
@@ -13,28 +13,28 @@ include(joinpath(dirname(@__FILE__), "hydro_valley.jl"))
 
 # deterministic
 deterministic_model = hydrovalleymodel(hasmarkovprice=false,hasstagewiseinflows=false)
-SDDP.solve(deterministic_model, max_iterations=10, cut_selection_frequency=1, print_level=0)
+SDDP.solve(deterministic_model, iteration_limit=10, cut_selection_frequency=1, print_level=0)
 @test isapprox(getbound(deterministic_model), 835.0, atol=1e-3)
 
 # stagewise inflows
 stagewise_model = hydrovalleymodel(hasmarkovprice=false)
-SDDP.solve(stagewise_model, max_iterations=20, print_level=0)
+SDDP.solve(stagewise_model, iteration_limit=20, print_level=0)
 @test isapprox(getbound(stagewise_model), 838.33, atol=1e-2)
 
 # markov prices
 markov_model = hydrovalleymodel(hasstagewiseinflows=false)
-SDDP.solve(markov_model, max_iterations=10, print_level=0)
+SDDP.solve(markov_model, iteration_limit=10, print_level=0)
 @test isapprox(getbound(markov_model), 851.8, atol=1e-2)
 
 # stagewise inflows and markov prices
 markov_stagewise_model = hydrovalleymodel(hasstagewiseinflows=true, hasmarkovprice=true)
-SDDP.solve(markov_stagewise_model, max_iterations=10, print_level=0)
+SDDP.solve(markov_stagewise_model, iteration_limit=10, print_level=0)
 @test isapprox(getbound(markov_stagewise_model), 855.0, atol=1e-3)
 
 # risk averse stagewise inflows and markov prices
 riskaverse_model = hydrovalleymodel(riskmeasure = EAVaR(lambda=0.5, beta=0.66))
 SDDP.solve(riskaverse_model,
-    max_iterations = 10,
+    iteration_limit = 10,
     print_level = 0
 )
 
@@ -44,7 +44,7 @@ SDDP.solve(riskaverse_model,
 worst_case_model = hydrovalleymodel(
     riskmeasure = EAVaR(lambda=0.5, beta=0.0), sense=:Min)
 SDDP.solve(worst_case_model,
-    max_iterations = 10,
+    iteration_limit = 10,
     simulation = MonteCarloSimulation(
         frequency = 2,
         min  = 20,
@@ -59,7 +59,7 @@ SDDP.solve(worst_case_model,
 # stagewise inflows and markov prices
 cutselection_model = hydrovalleymodel(cutoracle = LevelOneCutOracle(), sense=:Max)
 SDDP.solve(cutselection_model,
-    max_iterations          = 10,
+    iteration_limit          = 10,
     print_level = 0,
     cut_selection_frequency = 2
 )
@@ -69,10 +69,10 @@ SDDP.solve(cutselection_model,
 
 # Distributionally robust Optimization
 dro_model = hydrovalleymodel(hasmarkovprice=false, riskmeasure=DRO(sqrt(2/3)-1e-6))
-SDDP.solve(dro_model, max_iterations = 10, print_level=0)
+SDDP.solve(dro_model, iteration_limit = 10, print_level=0)
 @test isapprox(getbound(dro_model), 835.0, atol=1e-3)
 dro_model = hydrovalleymodel(hasmarkovprice=false, riskmeasure=DRO(1/6))
-SDDP.solve(dro_model, max_iterations = 20, print_level=0)
+SDDP.solve(dro_model, iteration_limit = 20, print_level=0)
 @test isapprox(getbound(dro_model), 836.695, atol=1e-3)
 # (Note) radius ≈ sqrt(2/3), will set all noise probabilities to zero except the worst case noise
 # (Why?):

--- a/examples/HydroValleys/simplified_hydrothermal_dispatch.jl
+++ b/examples/HydroValleys/simplified_hydrothermal_dispatch.jl
@@ -21,7 +21,7 @@ using SDDP, JuMP, Clp, Base.Test
 
 # Initialise SDDP Model
 m = SDDPModel(
-                  sense = :Min,          
+                  sense = :Min,
                  stages = 3,
                  solver = ClpSolver(),
         objective_bound = 0
@@ -69,7 +69,7 @@ solvestatus = solve(m,
                         min       = 10,
                         step      = 10,
                         max       = 100,
-                        termination = true
+                        terminate = true
                     ),
      print_level=0
 )

--- a/examples/HydroValleys/simplified_hydrothermal_dispatch.jl
+++ b/examples/HydroValleys/simplified_hydrothermal_dispatch.jl
@@ -62,7 +62,7 @@ end
 srand(11111)
 
 solvestatus = solve(m,
-    max_iterations = 20,
+    iteration_limit = 20,
     time_limit     = 600,
     simulation     = MonteCarloSimulation(
                         frequency = 5,

--- a/examples/Newsvendor/async_newsvendor.jl
+++ b/examples/Newsvendor/async_newsvendor.jl
@@ -136,7 +136,7 @@ solvestatus = SDDP.solve(m2,
                         min       = 5,
                         max       = 50,
                         step      = 5,
-                        termination = true
+                        terminate = true
                              )
 )
 

--- a/examples/Newsvendor/async_newsvendor.jl
+++ b/examples/Newsvendor/async_newsvendor.jl
@@ -86,7 +86,7 @@ end
 m = createmodel(EAVaR(beta   = 0.6, lambda = 0.5))
 
 
-@test_throws Exception SDDP.solve(m, print_level=0, max_iterations=30, solve_type=Asynchronous(slaves=[2]))
+@test_throws Exception SDDP.solve(m, print_level=0, iteration_limit=30, solve_type=Asynchronous(slaves=[2]))
 
 # slave processes
 slaves = workers()
@@ -97,7 +97,7 @@ slaves = workers()
 =#
 slave_steps = 2.0
 solvestatus = SDDP.solve(m,
-    max_iterations = 30,
+    iteration_limit = 30,
     solve_type     = Asynchronous(slaves=slaves, step=slave_steps),
    cut_output_file = "async.cuts",
     simulation     = MonteCarloSimulation(
@@ -109,7 +109,7 @@ solvestatus = SDDP.solve(m,
 )
 
 @test isapprox(getbound(m), 93.267, atol=1e-3)
-@test solvestatus == :max_iterations
+@test solvestatus == :iteration_limit
 
 sim = simulate(m, 100, [:stock, :pid])
 @test length(sim) == 100
@@ -122,13 +122,13 @@ m4 = createmodel(0.5Expectation() + 0.5AVaR(0.6))
 loadcuts!(m4, "async.cuts")
 rm("async.cuts")
 
-SDDP.solve(m4, max_iterations=1, solve_type=Asynchronous())
+SDDP.solve(m4, iteration_limit=1, solve_type=Asynchronous())
 @test isapprox(getbound(m), getbound(m4), atol=1e-3)
 
 m2 = createmodel(Expectation())
 
 solvestatus = SDDP.solve(m2,
-    max_iterations = 50, print_level=0,
+    iteration_limit = 50, print_level=0,
     solve_type     = Asynchronous(),
     cut_selection_frequency = 5,
     simulation     = MonteCarloSimulation(

--- a/examples/Newsvendor/newsvendor.jl
+++ b/examples/Newsvendor/newsvendor.jl
@@ -77,7 +77,7 @@ end
 news1 = newsvendormodel()
 
 @test SDDP.solve(news1,
-    max_iterations = 20,
+    iteration_limit = 20,
     cut_selection_frequency = 10,
     simulation     = MonteCarloSimulation(
                         frequency = 10,
@@ -94,7 +94,7 @@ news1 = newsvendormodel()
 
 news2 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
 @test SDDP.solve(news2,
-    max_iterations = 50,
+    iteration_limit = 50,
     print_level    = 0,
     simulation     = MonteCarloSimulation(
                         frequency = 10,
@@ -102,7 +102,7 @@ news2 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
                         max       = 500,
                         step      = 1
                              )
-) == :max_iterations
+) == :iteration_limit
 @test isapprox(getbound(news2), -93.267, atol=1e-3)
 results2 = simulate(news2, 500)
 @test length(results2) == 500
@@ -126,9 +126,9 @@ historical_results2 = simulate(news2, [:buy, :sell];
 news3 = newsvendormodel(riskmeasure=EAVaR(beta=0.6,lambda=0.5))
 cuts_file_name = "newsvendor_cuts.csv"
 @test SDDP.solve(news3,
-    max_iterations = 30,
+    iteration_limit = 30,
     print_level = 0,
-    cut_output_file = cuts_file_name) == :max_iterations
+    cut_output_file = cuts_file_name) == :iteration_limit
 
 srand(22222)
 results3 = simulate(news3, 500)

--- a/examples/Nonlinear/inventory-control.jl
+++ b/examples/Nonlinear/inventory-control.jl
@@ -32,5 +32,5 @@ m = SDDPModel(
     @stageobjective(sp, u + (x0 + u - w)^2)
 end
 
-solve(m, max_iterations=20, print_level=0)
+solve(m, iteration_limit=20, print_level=0)
 @test isapprox(getbound(m), 1.375)

--- a/examples/Nonlinear/log_auto_regressive.jl
+++ b/examples/Nonlinear/log_auto_regressive.jl
@@ -35,7 +35,7 @@ m = SDDPModel(
 end
 
 srand(123)
-solve(m, max_iterations=10, print_level=0)
+solve(m, iteration_limit=10, print_level=0)
 @test isapprox(getbound(m), 5585.8, atol=1e-1)
 s = simulate(m, 1, [:inflow′])
 ω = [0.9, 1.0, 1.1]

--- a/examples/Nonlinear/logs.jl
+++ b/examples/Nonlinear/logs.jl
@@ -23,5 +23,5 @@ m = SDDPModel(
         @stageobjective(sp, y)
     end
 end
-solve(m, max_iterations=10, print_level=0)
+solve(m, iteration_limit=10, print_level=0)
 @test isapprox(getbound(m), log(6) / 3, atol=1e-4)

--- a/examples/Nonlinear/simple_conic.jl
+++ b/examples/Nonlinear/simple_conic.jl
@@ -33,8 +33,8 @@ end
 Solve the model `m` and return the estimator for `data`.
 """
 function solvemodel!(m)
-    status = solve(m, max_iterations=20, print_level=0)
-    @test status == :max_iterations
+    status = solve(m, iteration_limit=20, print_level=0)
+    @test status == :iteration_limit
     d = simulate(m, 1, [:x′])
     return d[1][:x′][1]
 end

--- a/examples/PriceInterpolation/newsvendor.jl
+++ b/examples/PriceInterpolation/newsvendor.jl
@@ -74,13 +74,13 @@ for discretization in [1, 3]
     m = newsvendor_example(discretization)
     srand(123)
     status = SDDP.solve(m,
-        max_iterations = 50,
+        iteration_limit = 50,
         cut_output_file="price.cuts",
         print_level=0,
         # test cut selection with default oracle
         cut_selection_frequency = 25
     )
-    @test status == :max_iterations
+    @test status == :iteration_limit
     @test getbound(m) .<= 4.098
 
     # test round-tripping the cuts
@@ -91,8 +91,8 @@ for discretization in [1, 3]
         rm("price.cuts")
     end
     # we have to solve once more to initialize the second model
-    SDDP.solve(m, max_iterations=1, print_level=0)
-    SDDP.solve(m2, max_iterations=1, print_level=0)
+    SDDP.solve(m, iteration_limit=1, print_level=0)
+    SDDP.solve(m2, iteration_limit=1, print_level=0)
     @test isapprox(getbound(m2), getbound(m), atol=1e-4)
 
     # test value function plotting without launching a plot
@@ -158,7 +158,7 @@ end
 #
 #     for i in 1:200
 #         # add a cut
-#         status = SDDP.solve(m, max_iterations = 1, print_level=0)
+#         status = SDDP.solve(m, iteration_limit = 1, print_level=0)
 #
 #         # process points
 #         vf = SDDP.valueoracle(SDDP.getsubproblem(m, 2, 1))

--- a/examples/PriceInterpolation/perishablewidgets.jl
+++ b/examples/PriceInterpolation/perishablewidgets.jl
@@ -318,7 +318,7 @@ end
 
 @time status = SDDP.solve(m,
     # maximum number of cuts to be added to any individual subproblem
-    max_iterations = 300,
+    iteration_limit = 300,
 
     # time limit for solver (seconds)
     time_limit     = 20,

--- a/examples/PriceInterpolation/perishablewidgets.jl
+++ b/examples/PriceInterpolation/perishablewidgets.jl
@@ -344,12 +344,12 @@ end
             sice more simulations will only refine the estimate.
 
             If we reach max simulations and there is still evidence of
-            convergence, then we can terminate with termination=true.
+            convergence, then we can terminate with terminate=true.
         ==#
-        min         = 500,
-        step        = 100,
-        max         = 500,
-        termination = false
+        min       = 500,
+        step      = 100,
+        max       = 500,
+        terminate = false
     ),
 
     #  SDDP.jl will automatically chose the best solver but we can orverride

--- a/examples/PriceInterpolation/riverchain.jl
+++ b/examples/PriceInterpolation/riverchain.jl
@@ -125,7 +125,7 @@ end
 
 function runpaper(USE_AR1, valley_chain, name)
     m = buildmodel(USE_AR1, valley_chain)
-    solve(m, max_iterations = 2_000, log_file="$(name).log")
+    solve(m, iteration_limit = 2_000, log_file="$(name).log")
 
     SIMN = 1_000
     sim = simulate(m, SIMN, [:reservoir, :price, :generation_quantity])
@@ -173,7 +173,7 @@ m = buildmodel(false, [
     ]
 )
 srand(123)
-solve(m, max_iterations = 20, print_level=0, cut_output_file="river.cuts")
+solve(m, iteration_limit = 20, print_level=0, cut_output_file="river.cuts")
 @test getbound(m) >= -40_000
 
 # test cut round trip with multiple price dimensions
@@ -189,7 +189,7 @@ finally
     rm("river.cuts")
 end
 srand(123)
-SDDP.solve(m, max_iterations=1, print_level=0)
+SDDP.solve(m, iteration_limit=1, print_level=0)
 srand(123)
-SDDP.solve(m2, max_iterations=1, print_level=0)
+SDDP.solve(m2, iteration_limit=1, print_level=0)
 @test isapprox(getbound(m2), getbound(m), atol=1e-4)

--- a/examples/PriceInterpolation/simple_contracting.jl
+++ b/examples/PriceInterpolation/simple_contracting.jl
@@ -125,7 +125,7 @@ end
 # dynamic interpolation
 m = contracting_example()
 srand(123)
-SDDP.solve(m, max_iterations = 50, cut_selection_frequency=10, print_level=0)
+SDDP.solve(m, iteration_limit = 50, cut_selection_frequency=10, print_level=0)
 @test SDDP.getbound(m) <= 175.0
 
 # historical simulation
@@ -139,7 +139,7 @@ results = simulate(m, 500)
 # 3 fixed ribs
 m3 = contracting_example(3)
 srand(123)
-SDDP.solve(m3, max_iterations = 10, cut_selection_frequency=5, print_level=0)
+SDDP.solve(m3, iteration_limit = 10, cut_selection_frequency=5, print_level=0)
 @test SDDP.getbound(m3) <= 150.0
 
 # historical simulation
@@ -153,7 +153,7 @@ results = simulate(m3, 500)
 # 5 fixed ribs
 m5 = contracting_example(5)
 srand(123)
-SDDP.solve(m5, max_iterations = 10, print_level=0)
+SDDP.solve(m5, iteration_limit = 10, print_level=0)
 @test SDDP.getbound(m5) <= 150.0
 
 # historical simulation

--- a/examples/PriceInterpolation/simple_markov.jl
+++ b/examples/PriceInterpolation/simple_markov.jl
@@ -50,7 +50,7 @@ m = SDDPModel(
     @stageobjective(sp, price -> price * u)
 end
 
-solve(m, max_iterations = 50, print_level = 0)
+solve(m, iteration_limit = 50, print_level = 0)
 s = simulate(m, 100, [:price, :x, :u])
 for si in s
     if si[:markov][2] == 1

--- a/examples/PriceInterpolation/widget_thesis_example.jl
+++ b/examples/PriceInterpolation/widget_thesis_example.jl
@@ -77,7 +77,7 @@ if length(ARGS) > 0
         m = newsvendor_example(15)
         srand(123)
         status = SDDP.solve(m,
-            max_iterations = 10
+            iteration_limit = 10
         )
         s = simulate(m, 1_000, [:x, :x0, :u, :price])
 
@@ -104,7 +104,7 @@ if length(ARGS) > 0
             m = newsvendor_example(N)
             srand(123)
             status = SDDP.solve(m,
-                max_iterations = 50,
+                iteration_limit = 50,
                 print_level=0
             )
             push!(bounds , getbound(m))
@@ -119,7 +119,7 @@ if length(ARGS) > 0
         m = newsvendor_example(1)
         srand(123)
         status = SDDP.solve(m,
-            max_iterations = 500
+            iteration_limit = 500
         )
         bound = [l.bound for l in m.log]
         open("dynamic.bound.csv", "w") do io
@@ -130,9 +130,9 @@ if length(ARGS) > 0
     elseif ARGS[1] == "hybrid"
         # warm up Julia JIT
         m = newsvendor_example(1)
-        SDDP.solve(m, max_iterations = 1)
+        SDDP.solve(m, iteration_limit = 1)
         m = newsvendor_example(3)
-        SDDP.solve(m, max_iterations = 1)
+        SDDP.solve(m, iteration_limit = 1)
 
         # Dynamic Only
         m = newsvendor_example(1)

--- a/examples/StochDynamicProgramming.jl/multistock-example.jl
+++ b/examples/StochDynamicProgramming.jl/multistock-example.jl
@@ -46,7 +46,7 @@ m = SDDPModel(
     @stageobjective(sp, (sin(3 * stage) - 1) * sum(control))
 end
 
-status = SDDP.solve(m, max_iterations = 100,
+status = SDDP.solve(m, iteration_limit = 100,
 print_level = 0)
 @test isapprox(SDDP.getbound(m), -4.349, atol=0.01)
 

--- a/examples/StochDynamicProgramming.jl/stock-example.jl
+++ b/examples/StochDynamicProgramming.jl/stock-example.jl
@@ -39,7 +39,7 @@ m = SDDPModel(
     @stageobjective(sp, (sin(3 * stage) - 1) * control)
 end
 
-status = SDDP.solve(m, max_iterations = 50,
+status = SDDP.solve(m, iteration_limit = 50,
 print_level = 0)
 @test isapprox(SDDP.getbound(m), -1.471, atol=0.001)
 

--- a/examples/StructDualDynProg.jl/prob5.2_2stages.jl
+++ b/examples/StructDualDynProg.jl/prob5.2_2stages.jl
@@ -53,7 +53,7 @@ mod = SDDPModel(
 end
 
 status = SDDP.solve(mod,
-    max_iterations = 50,
+    iteration_limit = 50,
     print_level    = 0,
     simulation     = MonteCarloSimulation(
         frequency = 10,

--- a/examples/StructDualDynProg.jl/prob5.2_3stages.jl
+++ b/examples/StructDualDynProg.jl/prob5.2_3stages.jl
@@ -52,7 +52,7 @@ mod = SDDPModel(
 end
 
 status = SDDP.solve(mod,
-    max_iterations = 30,
+    iteration_limit = 30,
     print_level    = 0,
     simulation     = MonteCarloSimulation(
         frequency = 10,

--- a/examples/simple_objective_noise.jl
+++ b/examples/simple_objective_noise.jl
@@ -25,7 +25,7 @@ function solve_model(noise_probability)
             setnoiseprobability!(sp, noise_probability)
         end
     end
-    solve(m,  max_iterations = 5, print_level=0, cut_selection_frequency = 5)
+    solve(m,  iteration_limit = 5, print_level=0, cut_selection_frequency = 5)
     m
 end
 

--- a/examples/visualize_value_function.jl
+++ b/examples/visualize_value_function.jl
@@ -45,7 +45,7 @@ m = SDDPModel(
 end
 
 srand(111)
-@time status = solve(m, max_iterations = 30)
+@time status = solve(m, iteration_limit = 30)
 
 #=
     These lines are commented out for testing

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -355,8 +355,8 @@ function JuMP.solve(::Serial, m::SDDPModel, settings::Settings=Settings())
         end
 
         iteration += 1
-        if iteration > settings.max_iterations
-            status = :max_iterations
+        if iteration > settings.iteration_limit
+            status = :iteration_limit
             keep_iterating = false
         end
 
@@ -393,11 +393,10 @@ control the solution process.
  * `m`: the SDDPModel to solve
 
 # Keyword arguments
- * `max_iterations::Int`:
+ * `iteration_limit::Int`:
     The maximum number of cuts to add to a single stage problem before terminating.
-    Defaults to `10`.
  * `time_limit::Real`:
-    The maximum number of seconds (in real time) to compute for before termination.
+    The maximum number of seconds to compute for before termination.
     Defaults to `Inf`.
  * `simulation::MonteCarloSimulation`: see `MonteCarloSimulation`
  * `bound_convergence::BoundConvergence`: see `BoundConvergence`
@@ -435,13 +434,14 @@ control the solution process.
     * `:solving`
     * `:interrupted`
     * `:converged`
-    * `:max_iterations`
+    * `:iteration_limit`
     * `:bound_convergence`
     * `:time_limit`
 
 """
 function JuMP.solve(m::SDDPModel;
-        max_iterations::Int       = Int(1e9),
+        iteration_limit::Int      = Int(1e9),
+        max_iterations::Union{Int, Void} = nothing,
         time_limit::Real          = Inf, # seconds
         simulation = MonteCarloSimulation(
                 frequency   = 0,
@@ -466,6 +466,10 @@ function JuMP.solve(m::SDDPModel;
         reduce_memory_footprint      = false,
         cut_output_file::String      = ""
     )
+    if max_iterations != nothing
+        warn("The keyword `max_iterations` is deprecated. Use `iteration_limit` instead.")
+        iteration_limit = max_iterations
+    end
     reset_timer!(TIMER)
 
     cut_output_file_handle = if cut_output_file != ""
@@ -477,7 +481,7 @@ function JuMP.solve(m::SDDPModel;
     end
 
     settings = Settings(
-        max_iterations,
+        iteration_limit,
         time_limit,
         simulation,
         bound_convergence,

--- a/src/SDDP.jl
+++ b/src/SDDP.jl
@@ -444,12 +444,12 @@ function JuMP.solve(m::SDDPModel;
         max_iterations::Union{Int, Void} = nothing,
         time_limit::Real          = Inf, # seconds
         simulation = MonteCarloSimulation(
-                frequency   = 0,
-                min         = 20,
-                step        = 1,
-                max         = 20,
-                confidence  = 0.95,
-                termination = false
+                frequency  = 0,
+                min        = 20,
+                step       = 1,
+                max        = 20,
+                confidence = 0.95,
+                terminate  = false
             ),
         bound_convergence = BoundConvergence(
                 iterations = 0,

--- a/src/solve_asynchronous.jl
+++ b/src/solve_asynchronous.jl
@@ -154,8 +154,8 @@ function JuMP.solve(async::Asynchronous, m::SDDPModel{T}, settings::Settings=Set
                             reset!(objectives)
                             simidx = 1
                         end
-                        if it > settings.max_iterations
-                            status = :max_iterations
+                        if it > settings.iteration_limit
+                            status = :iteration_limit
                             break
                         end
                         newcuts = deepcopy(slaves[p])

--- a/src/typedefinitions.jl
+++ b/src/typedefinitions.jl
@@ -232,7 +232,7 @@ Defaults to `false`.
 MonteCarloSimulation(;frequency=0,min=20,max=0,step=1,confidence=0.95,termination=false) = MonteCarloSimulation(frequency,collect(min:step:max),confidence,termination)
 
 struct Settings
-    max_iterations::Int
+    iteration_limit::Int
     time_limit::Float64
     simulation::MonteCarloSimulation
     bound_convergence::BoundConvergence

--- a/src/typedefinitions.jl
+++ b/src/typedefinitions.jl
@@ -229,7 +229,26 @@ Whether to terminate the solution algorithm with the status `:converged` if the
 deterministic bound is with in the statistical bound after `max` simulations.
 Defaults to `false`.
 """
-MonteCarloSimulation(;frequency=0,min=20,max=0,step=1,confidence=0.95,termination=false) = MonteCarloSimulation(frequency,collect(min:step:max),confidence,termination)
+function MonteCarloSimulation(;
+    frequency   = 0,
+    min         = 20,
+    max         = 0,
+    step        = 1,
+    confidence  = 0.95,
+    terminate   = false,
+    termination = nothing
+    )
+    if termination != nothing
+        warn("The keyword `termination` is deprecated. Use `terminate` instead.")
+        terminate = termination
+    end
+    MonteCarloSimulation(
+        frequency,
+        collect(min:step:max),
+        confidence,
+        terminate
+    )
+end
 
 struct Settings
     iteration_limit::Int

--- a/test/sddpmodels.jl
+++ b/test/sddpmodels.jl
@@ -94,8 +94,8 @@ using Clp
             @rhsnoise(sp, i=1:2, x <= i)
             @stageobjective(sp, i=1:2, i * x)
         end
-        status = solve(m, max_iterations=1, print_level=0, reduce_memory_footprint=true)
-        @test status == :max_iterations
+        status = solve(m, iteration_limit=1, print_level=0, reduce_memory_footprint=true)
+        @test status == :iteration_limit
         sp = SDDP.getsubproblem(m, 1, 1)
         for con in sp.linconstr
             @test con.terms == JuMP.AffExpr(0.0)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -29,8 +29,8 @@ end
         @constraint(sp, x <= -1)
         @stageobjective(sp, i=1:2, i * x)
     end
-    
-    @test_throws Exception solve(m, max_iterations=1)
+
+    @test_throws Exception solve(m, iteration_limit=1)
     @test isfile("infeasible_subproblem.lp")
     rm("infeasible_subproblem.lp")
 end

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -88,7 +88,7 @@
             srand(12345)
 
             markov_stagewise_model = hydrovalleymodel(hasstagewiseinflows=true, hasmarkovprice=true)
-            SDDP.solve(markov_stagewise_model, max_iterations=10, print_level=0)
+            SDDP.solve(markov_stagewise_model, iteration_limit=10, print_level=0)
             @test isapprox(getbound(markov_stagewise_model), 855.0, atol=1e-3)
 
             results = simulate(markov_stagewise_model, 5, [:reservoir])


### PR DESCRIPTION
- Change `max_iterations` to `iteration_limit`: 
This change brings the API into line with the definitions in my thesis
and better aligns with `time_limit`.
- Change `termination` to `terminate`:
A pedantic change to the verb because the noun annoyed me. 

Unfortunately these are pretty big changes for users, but I added a 
deprecation warnings.

