### PR TITLE
Fix bound calculation with multiple Markov states in first stage

### DIFF
--- a/test/sddpmodels.jl
+++ b/test/sddpmodels.jl
@@ -136,3 +136,14 @@ using Clp
         end
     end
 end
+
+@testset "Markov Issue #120" begin
+    m = SDDPModel(stages=2, sense=:Min, objective_bound=0.0, solver=ClpSolver(),
+            markov_transition = [ [0.5 0.5], [0.5 0.5; 0.5 0.5] ]) do sp, t, i
+        @state(sp, x>=0, x0==2)
+        @rhsnoise(sp, w=[-1, 1], x == x0 + w)
+        @stageobjective(sp, (t + i) * x)
+    end
+    solve(m, iteration_limit=20, print_level=0)
+    @test getbound(m) ≈ 12.0
+end


### PR DESCRIPTION
As reported by @rodripor, the bound calculation did not account for multiple Markov states in the first stage.

There is an unresolved question as to what the bound should be when there are multiple Markov states (or stagewise-independent noise terms for that matter). Should it just be the expectation of all of the possible first stage realizations? Or some risk-adjusted value? Even though we do not explicitly optimize the risk-adjusted value, it should attain the optimal solution from monotonicity.

Closes https://github.com/odow/SDDP.jl/issues/120