### PR TITLE
Add examples from Ahmed's Stochastic Lipschitz Dynamic Programming paper

### DIFF
--- a/examples/sldp_example_one.jl
+++ b/examples/sldp_example_one.jl
@@ -1,0 +1,38 @@
+#  Copyright 2019, Oscar Dowson.
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This example is derived from Section 4.2 of the paper:
+#   Ahmed, S., Cabral, F. G., & da Costa, B. F. P. (2019). Stochastic Lipschitz
+#   Dynamic Programming. Optimization Online.
+#   URL: http://www.optimization-online.org/DB_FILE/2019/05/7193.pdf
+
+using SDDP, GLPK, Test
+
+function sldp_example_one()
+    model = SDDP.LinearPolicyGraph(
+            stages = 8,
+            lower_bound = 0.0,
+            optimizer = with_optimizer(GLPK.Optimizer)
+            ) do sp, t
+        @variable(sp, x, SDDP.State, initial_value = 2.0)
+        @variables(sp, begin
+            x⁺ >= 0
+            x⁻ >= 0
+            0 <= u <= 1, Bin
+            ω
+        end)
+        @stageobjective(sp, 0.9^(t-1) * (x⁺ + x⁻))
+        @constraints(sp, begin
+            x.out == x.in + 2 * u - 1 + ω
+            x⁺ >= x.out
+            x⁻ >= x.in
+        end)
+        SDDP.parameterize(φ -> JuMP.fix(ω, φ), sp, range(-0.1, stop=0.1, length=10))
+    end
+    SDDP.train(model, iteration_limit = 100, print_level = 0)
+    @test SDDP.calculate_bound(model) <= 4.0
+end
+
+sldp_example_one()

--- a/examples/sldp_example_one.jl
+++ b/examples/sldp_example_one.jl
@@ -29,10 +29,13 @@ function sldp_example_one()
             x⁺ >= x.out
             x⁻ >= x.in
         end)
-        SDDP.parameterize(φ -> JuMP.fix(ω, φ), sp, range(-0.1, stop=0.1, length=10))
+        points = [-0.5, 0.3, 0.4, 1.1, 1.5]
+        SDDP.parameterize(φ -> JuMP.fix(ω, φ), sp, [points; -points])
     end
     SDDP.train(model, iteration_limit = 100, print_level = 0)
-    @test SDDP.calculate_bound(model) <= 4.0
+    # TODO(odow): include the actual set of points when known, and update this
+    # bound. The paper reports a bound of [3.085, 3.313].
+    @test SDDP.calculate_bound(model) ≈ 5.49 atol=0.1
 end
 
 sldp_example_one()

--- a/examples/sldp_example_two.jl
+++ b/examples/sldp_example_two.jl
@@ -1,0 +1,52 @@
+#  Copyright 2019, Oscar Dowson.
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This example is derived from Section 4.3 of the paper:
+#   Ahmed, S., Cabral, F. G., & da Costa, B. F. P. (2019). Stochastic Lipschitz
+#   Dynamic Programming. Optimization Online.
+#   URL: http://www.optimization-online.org/DB_FILE/2019/05/7193.pdf
+
+using SDDP, GLPK, Test
+
+function sldp_example_two(; first_stage_integer::Bool = true, N = 2)
+    model = SDDP.LinearPolicyGraph(
+            stages = 2,
+            lower_bound = -100.0,
+            optimizer = with_optimizer(GLPK.Optimizer)
+            ) do sp, t
+        @variable(sp, 0 <= x[1:2] <= 5, SDDP.State, initial_value = 0.0)
+        if t == 1
+            if first_stage_integer
+                @variable(sp, 0 <= u[1:2] <= 5, Int)
+                @constraint(sp, [i=1:2], u[i] == x[i].out)
+            end
+            @stageobjective(sp, -1.5x[1].out - 4x[2].out)
+        else
+            @variable(sp, 0 <= y[1:4] <= 1, Bin)
+            @variable(sp, ω[1:2])
+            @stageobjective(sp, -16y[1] - 19y[2] - 23y[3] - 28y[4])
+            @constraint(sp, 2y[1] + 3y[2] + 4y[3] + 5y[4] <= ω[1] - x[1].in)
+            @constraint(sp, 6y[1] + 1y[2] + 3y[3] + 2y[4] <= ω[2] - x[2].in)
+            steps = range(5, stop=15, length=N)
+            SDDP.parameterize(sp, [[i, j] for i in steps for j in steps]) do φ
+                JuMP.fix.(ω, φ)
+            end
+        end
+    end
+    SDDP.train(model, iteration_limit = 100, print_level = 0)
+    bound = SDDP.calculate_bound(model)
+
+    if N == 2
+        @test bound <= -57.0
+    elseif N == 3
+        @test bound <= -59.33
+    elseif N == 6
+        @test bound <= -61.22
+    end
+end
+
+sldp_example_two(N = 2)
+sldp_example_two(N = 3)
+sldp_example_two(N = 6)


### PR DESCRIPTION
Example one isn't correct, because the paper doesn't explain what noise supports they used. All it says is

<img width="707" alt="image" src="https://user-images.githubusercontent.com/8177701/57809249-b295bc00-772a-11e9-889d-56eabbb771c3.png">

Edit: via email, @bfpc says this
<img width="707" alt="image" src="https://user-images.githubusercontent.com/8177701/57810292-06a1a000-772d-11e9-8069-59f07452f16a.png">
