### PR TITLE
Update SLDP examples with actual random values

### DIFF
--- a/examples/sldp_example_one.jl
+++ b/examples/sldp_example_one.jl
@@ -27,15 +27,15 @@ function sldp_example_one()
         @constraints(sp, begin
             x.out == x.in + 2 * u - 1 + ω
             x⁺ >= x.out
-            x⁻ >= x.in
+            x⁻ >= x.out
         end)
-        points = [-0.5, 0.3, 0.4, 1.1, 1.5]
+        points = [
+            -0.3089653673606697, -0.2718277412744214, -0.09611178608243474,
+            0.24645863921577763, 0.5204224537256875]
         SDDP.parameterize(φ -> JuMP.fix(ω, φ), sp, [points; -points])
     end
     SDDP.train(model, iteration_limit = 100, print_level = 0)
-    # TODO(odow): include the actual set of points when known, and update this
-    # bound. The paper reports a bound of [3.085, 3.313].
-    @test SDDP.calculate_bound(model) ≈ 5.49 atol=0.1
+    @test SDDP.calculate_bound(model) <= 3.313
 end
 
 sldp_example_one()


### PR DESCRIPTION
From @bfpc 
<img width="234" alt="image" src="https://user-images.githubusercontent.com/8177701/57860126-e2d86b80-77b9-11e9-8a60-25b5846a27a0.png">

(Note: this was on Julia 0.6, but random number generator in Julia 1.0 is the same.)

```Julia
import Random
Random.seed!(11111)
sort(0.4 .* randn(5))
```