### PR TITLE
Update add

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,9 +33,9 @@ If you get an error like:
 run
 
 ```julia
-import Pkg
-Pkg.add("https://github.com/odow/MathOptFormat.jl.git")
-Pkg.add("https://github.com/odow/SDDP.jl.git")
+]
+add https://github.com/odow/MathOptFormat.jl.git
+add https://github.com/odow/SDDP.jl.git
 ```
 
 ### Want the old version?


### PR DESCRIPTION
I think this is outdated, now it has to use PackageSpec. I think it is simple to use ].

```julia
import Pkg
Pkg.add("https://github.com/odow/SDDP.jl.git")
```
It don't work in Julia 1.0.3 and I get the following error in Julia 1.1:

> ERROR: https://github.com/odow/SDDP.jl.git is not a valid packagename.
> The argument appears to be a URL or path, perhaps you meant `Pkg.add(PackageSpec(url="..."))` or `Pkg.add(PackageSpec(path="..."))`.
> Stacktrace:
>  [1] pkgerror(::String) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/Types.jl:120
>  [2] check_package_name(::String, ::Symbol) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:28
>  [3] #14 at ./none:0 [inlined]
>  [4] iterate at ./generator.jl:47 [inlined]
>  [5] collect(::Base.Generator{Array{String,1},getfield(Pkg.API, Symbol("##14#15")){Symbol}}) at ./array.jl:606
>  [6] #add_or_develop#13 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:34 [inlined]
>  [7] #add_or_develop at ./none:0 [inlined]
>  [8] #add_or_develop#12(::Base.Iterators.Pairs{Symbol,Symbol,Tuple{Symbol},NamedTuple{(:mode,),Tuple{Symbol}}}, ::Function, ::String) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:33
>  [9] #add_or_develop at ./none:0 [inlined]
>  [10] #add#22 at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:64 [inlined]
>  [11] add(::String) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/Pkg/src/API.jl:64
>  [12] top-level scope at none:0
