### PR TITLE
Fix deterministic for affine expr with no terms

### DIFF
--- a/src/deterministic_equivalent.jl
+++ b/src/deterministic_equivalent.jl
@@ -132,6 +132,9 @@ function copy_and_replace_variables(
     src::JuMP.GenericAffExpr,
     src_to_dest_variable::Dict{JuMP.VariableRef,JuMP.VariableRef},
 )
+    if length(src.terms) == 0
+        return src
+    end
     return JuMP.GenericAffExpr(
         src.constant,
         (src_to_dest_variable[key] => val for (key, val) in src.terms)...,

--- a/src/deterministic_equivalent.jl
+++ b/src/deterministic_equivalent.jl
@@ -121,6 +121,8 @@ function add_node_to_scenario_tree(
     return
 end
 
+copy_and_replace_variables(src::Real, ::Dict{JuMP.VariableRef,JuMP.VariableRef}) = src
+
 function copy_and_replace_variables(
     src::JuMP.VariableRef,
     src_to_dest_variable::Dict{JuMP.VariableRef,JuMP.VariableRef},
@@ -136,13 +138,14 @@ function copy_and_replace_variables(
         return src
     end
     return JuMP.GenericAffExpr(
-        src.constant,
-        (src_to_dest_variable[key] => val for (key, val) in src.terms)...,
+        src.constant, (src_to_dest_variable[key] => val for (key, val) in src.terms)...,
     )
 end
 
 function copy_and_replace_variables(src::Any, ::Dict{JuMP.VariableRef,JuMP.VariableRef})
-    throw_detequiv_error("`copy_and_replace_variables` is not implemented for functions like `$(src)`.")
+    throw_detequiv_error(
+        "`copy_and_replace_variables` is not implemented for functions like `$(src)`."
+    )
 end
 
 function add_scenario_to_ef(

--- a/src/deterministic_equivalent.jl
+++ b/src/deterministic_equivalent.jl
@@ -140,11 +140,11 @@ function copy_and_replace_variables(
     src::JuMP.GenericAffExpr,
     src_to_dest_variable::Dict{JuMP.VariableRef,JuMP.VariableRef},
 )
-    if length(src.terms) == 0
-        return src
-    end
     return JuMP.GenericAffExpr(
-        src.constant, (src_to_dest_variable[key] => val for (key, val) in src.terms)...,
+        src.constant,
+        Pair{VariableRef,Float64}[
+            src_to_dest_variable[key] => val for (key, val) in src.terms
+        ]
     )
 end
 

--- a/test/deterministic_equivalent.jl
+++ b/test/deterministic_equivalent.jl
@@ -154,3 +154,30 @@ end
         SDDP.deterministic_equivalent(model)
     )
 end
+
+@testset "Edge cases" begin
+    @testset "Constant objective" begin
+        model = SDDP.LinearPolicyGraph(
+            stages = 2, lower_bound = 0.0, optimizer = with_optimizer(GLPK.Optimizer),
+        ) do sp, t
+            @variable(sp, x >= 0, SDDP.State, initial_value = 0.0)
+            @stageobjective(sp, 1.0)
+        end
+        d = SDDP.deterministic_equivalent(model, with_optimizer(GLPK.Optimizer))
+        optimize!(d)
+        @test objective_value(d) == 2.0
+    end
+
+    @testset "Constraint with no terms" begin
+        model = SDDP.LinearPolicyGraph(
+            stages = 2, lower_bound = 0.0, optimizer = with_optimizer(GLPK.Optimizer),
+        ) do sp, t
+            @variable(sp, x >= 0, SDDP.State, initial_value = 0.0)
+            @constraint(sp, x.out <= x.out)
+            @stageobjective(sp, 1.0)
+        end
+        d = SDDP.deterministic_equivalent(model, with_optimizer(GLPK.Optimizer))
+        optimize!(d)
+        @test objective_value(d) == 2.0
+    end
+end

--- a/test/deterministic_equivalent.jl
+++ b/test/deterministic_equivalent.jl
@@ -180,4 +180,46 @@ end
         optimize!(d)
         @test objective_value(d) == 2.0
     end
+
+    @testset "Quadratic Expr" begin
+        model = SDDP.LinearPolicyGraph(
+            stages = 2, lower_bound = 0.0,
+        ) do sp, t
+            @variable(sp, x >= 0, SDDP.State, initial_value = 0.0)
+            @constraint(sp, x.in^2 <= x.out)
+            @stageobjective(sp, x.out)
+        end
+        d = SDDP.deterministic_equivalent(model)
+        @test in(
+            (GenericQuadExpr{Float64,VariableRef}, MOI.LessThan{Float64}),
+            list_of_constraint_types(d)
+        )
+    end
+
+    @testset "Quadratic Expr no quad terms" begin
+        model = SDDP.LinearPolicyGraph(
+            stages = 2, lower_bound = 0.0,
+        ) do sp, t
+            @variable(sp, x >= 0, SDDP.State, initial_value = 0.0)
+            @constraint(sp, x.in^2 <= x.out + x.in^2)
+            @stageobjective(sp, x.out)
+        end
+        d = SDDP.deterministic_equivalent(model)
+        @test in(
+            (GenericQuadExpr{Float64,VariableRef}, MOI.LessThan{Float64}),
+            list_of_constraint_types(d)
+        )
+    end
+
+    @testset "Vector-valued functions" begin
+        model = SDDP.LinearPolicyGraph(
+            stages = 2, lower_bound = 0.0,
+        ) do sp, t
+            @variable(sp, x >= 0, SDDP.State, initial_value = 0.0)
+            @constraint(sp, [x.in, x.out] in MOI.SOS1([1.0, 2.0]))
+            @stageobjective(sp, x.out)
+        end
+        d = SDDP.deterministic_equivalent(model)
+        @test (Vector{VariableRef}, MOI.SOS1{Float64}) in list_of_constraint_types(d)
+    end
 end


### PR DESCRIPTION
cc @haoxiangyang89 

This fixes the "K not defined." But we still throw on:
```julia
ERROR: Unable to formulate deterministic equivalent: `copy_and_replace_variables` is not implemented for functions like `-d[1]*G[1] + 0.5 d[1]*s[1,1] + t[0]_out - t[1]_out + 2.5 x[1,1]_out`.
```
because I didn't address quadratics yet.