### PR TITLE
Relax check for probabilities in MarkovianGraph

### DIFF
--- a/src/user_interface.jl
+++ b/src/user_interface.jl
@@ -252,8 +252,8 @@ function MarkovianGraph(transition_matrices::Vector{Matrix{Float64}})
         if !all(transition .>= 0.0)
             error("Entries in the transition matrix must be non-negative.")
         end
-        if !all(0.0 .<= sum(transition; dims = 2) .<= 1.0)
-            error("Rows in the transition matrix must sum to between 0.0 and " * "1.0.")
+        if !all(0.0 - 1e-8 .<= sum(transition; dims = 2) .<= 1.0 + 1e-8)
+            error("Rows in the transition matrix must sum to between 0.0 and 1.0.")
         end
         if stage > 1
             if size(transition_matrices[stage-1], 2) != size(transition, 1)


### PR DESCRIPTION
Overlooked cases with rounding error:
```Julia
julia> sum(fill(1 / 9, 9))
1.0000000000000002
```