### PR TITLE
Add RiskAdjustedForwardPass

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -66,6 +66,7 @@ SDDP.Asynchronous
 SDDP.AbstractForwardPass
 SDDP.DefaultForwardPass
 SDDP.RevisitingForwardPass
+SDDP.RiskAdjustedForwardPass
 ```
 
 ### Risk Measures

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -864,7 +864,12 @@ Train the policy for `model`. Keyword arguments:
  - `parallel_scheme::AbstractParallelScheme`: specify a scheme for solving in parallel.
     Defaults to `Serial()`.
 
- - `forwad_pass::AbstractForwardPass`: specify a scheme to use for the forward passes.
+ - `forward_pass::AbstractForwardPass`: specify a scheme to use for the forward
+   passes.
+
+ - `forward_pass_resampling_probability::Union{Nothing,Float64}`: set to a value
+   in `(0, 1)` to enable [`RiskAdjustedForwardPass`](@ref). Defaults to
+   `nothing` (disabled).
 
 There is also a special option for infinite horizon problems
 
@@ -891,7 +896,15 @@ function train(
     dashboard::Bool = false,
     parallel_scheme::AbstractParallelScheme = Serial(),
     forward_pass::AbstractForwardPass = DefaultForwardPass(),
+    forward_pass_resampling_probability::Union{Nothing,Float64} = nothing,
 )
+    if forward_pass_resampling_probability !== nothing
+        forward_pass = RiskAdjustedForwardPass(
+            forward_pass = forward_pass,
+            risk_measure = risk_measure,
+            resampling_probability = forward_pass_resampling_probability,
+        )
+    end
     # Reset the TimerOutput.
     TimerOutputs.reset_timer!(SDDP_TIMER)
     log_file_handle = open(log_file, "a")

--- a/src/plugins/forward_passes.jl
+++ b/src/plugins/forward_passes.jl
@@ -263,7 +263,7 @@ function forward_pass(
     fill!(fp.nominal_probability, 1 / length(fp.nominal_probability))
     push!(fp.adjusted_probability, 0.0)
     push!(fp.archive, pass)
-    push!(fp.resampling_count, 1)
+    push!(fp.resample_count, 1)
     adjust_probability(
         fp.risk_measure,
         fp.adjusted_probability,

--- a/test/plugins/forward_passes.jl
+++ b/test/plugins/forward_passes.jl
@@ -133,7 +133,7 @@ end
     SDDP.train(
         model;
         print_level = 0,
-        iteration_limit = 10,
+        iteration_limit = 20,
         forward_pass = forward_pass,
     )
     @test length(forward_pass.archive) < 10


### PR DESCRIPTION
Adding this so I can experiment with the entropic model.

For risk-averse models, we want to sample bad trajectories more frequently. The main motivation is that if you're using a risk measure, you care about the tails. So we want a good policy in the tails, which means adding more cuts in the tails. But if we sample with the nominal distribution, then the tails aren't going to get many cuts!

The standard way around this is to use some sort of importance sampling on the forward pass (e.g., https://arxiv.org/pdf/1901.01302.pdf, https://arxiv.org/pdf/2001.06026.pdf, probably some others, msppy calls it "biased sampling").

This takes a different approach: we just periodically resample bad trajectories _that we have already seen_, sampled based on the risk-adjusted probability of the cumulative objective values (I don't know what it will do if you have a cyclic policy graph? Repeatedly sample the longest trajectories?)

This is potentially better than the importance sampling, because it refines things we actually care about (bad trajectories). 

The importance sampling approach could be overly conservative, because it assumes at each time step that a bad thing is more likely to happen, when in reality it's unlikely to go bad-bad-bad (if this was true, you're modeling it wrong; use a Markovian policy graph). There is also evidence that resampling trajectories can be a good thing (http://www.optimization-online.org/DB_HTML/2021/05/8397.html).

The other reason not to do importance sampling is that it's hard to implement because the data-structures aren't setup to do it :(. We'd need a way for each node to track a single vector of probabilities, instead of node->realization pairs, and a way for the backward pass to communicate the risk-adjusted probabilities with the forward pass. 