### PR TITLE
Fix bug in lagrangian duality

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -382,7 +382,9 @@ function solve_subproblem(
     end
     state = get_outgoing_state(node)
     stage_objective = stage_objective_value(node.stage_objective)
-    objective, dual_values = get_dual_solution(node, duality_handler)
+    TimerOutputs.@timeit SDDP_TIMER "get_dual_solution" begin
+        objective, dual_values = get_dual_solution(node, duality_handler)
+    end
     if node.post_optimize_hook !== nothing
         node.post_optimize_hook(pre_optimize_ret)
     end


### PR DESCRIPTION
StrengthenedConicDuality can't use the higher bounds because the continuous dual solution is likely infeasible. If the bounds are too tight, then we'll get an incorrect dual objective value.

There must be something like adding a feasibility cut. But I don't know how that would work computationally. Using wide bounds seems okay.

cc @zfornier this fixes the StrengthenedConicDuality case, but not the LagrangianDuality. I obviously need to play with your example more.