### PR TITLE
Fix magnitude warning with zero coefficients

### DIFF
--- a/src/plugins/bellman_functions.jl
+++ b/src/plugins/bellman_functions.jl
@@ -51,7 +51,7 @@ mutable struct ConvexApproximation
     end
 end
 
-_magnitude(x) = x ≈ 0 ? 0 : log10(abs(x))
+_magnitude(x) = abs(x) > 0 ? log10(abs(x)) : 0
 
 function _dynamic_range_warning(intercept, coefficients)
     lo = hi = _magnitude(intercept)


### PR DESCRIPTION
Avoids this stuff
```
       27L   9.467399e+05   2.713322e+04   3.014880e+01          1       6480
       28L   7.112808e+05   2.713324e+04   3.205402e+01          1       6720
┌ Warning: Found a cut with a mix of small and large coefficients.
│     The order of magnitude difference is 13.898108414238555.
│     The smallest cofficient is -1.264420666934206e-14.
│     The largest coefficient is 0.0.
│ 
│ You can ignore this warning, but it may be an indication of numerical issues.
│ 
│ Consider rescaling your model by using different units, e.g, kilometers instead
│ of meters. You should also consider reducing the accuracy of your input data (if
│ you haven't already). For example, it probably doesn't make sense to measure the
│ inflow into a reservoir to 10 decimal places.
└ @ SDDP ~/.julia/dev/SDDP/src/plugins/bellman_functions.jl:68
```