### PR TITLE
Fix issue with set_silent in a subproblem

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -306,6 +306,7 @@ function _initialize_solver(node::Node; throw_error::Bool)
             )
         end
         set_optimizer(node.subproblem, node.optimizer)
+        set_silent(node.subproblem)
     end
     return
 end

--- a/src/user_interface.jl
+++ b/src/user_interface.jl
@@ -679,7 +679,6 @@ function PolicyGraph(
         subproblem.ext[:sddp_policy_graph] = policy_graph
         policy_graph.nodes[node_index] = subproblem.ext[:sddp_node] = node
         JuMP.set_objective_sense(subproblem, policy_graph.objective_sense)
-        set_silent(subproblem)
         builder(subproblem, node_index)
         # Add a dummy noise here so that all nodes have at least one noise term.
         if length(node.noise_terms) == 0


### PR DESCRIPTION
Temporary fix for https://github.com/odow/SDDP.jl/issues/495.

There's really no reason to print every subproblem. And this avoids people having to call `set_silent` themselves.