### PR TITLE
Variable Naming in Deterministic Equivalent

### DIFF
--- a/src/deterministic_equivalent.jl
+++ b/src/deterministic_equivalent.jl
@@ -131,7 +131,15 @@ function add_scenario_to_ef(
     var_src_to_dest = Dict{JuMP.VariableRef,JuMP.VariableRef}()
     for (src, dest) in zip(src_variables, x)
         var_src_to_dest[src] = dest
-        JuMP.set_name(dest, JuMP.name(src))
+        name = JuMP.name(src)
+        if !isempty(name)
+            # append node index to original variable name
+            JuMP.set_name(dest, string(name, "#", node.index))
+        else
+            # append node index to original variable index
+            var_name = string("_[", index(src).value, "]")
+            JuMP.set_name(dest, string(var_name, "#", node.index))
+        end
     end
     # Add constraints:
     for (F, S) in JuMP.list_of_constraint_types(node.subproblem)


### PR DESCRIPTION
When inspecting solution values in a deterministic equivalent model, I don't see a way to identify the node in which a particular variable was created.

In the following example, there is no way to separate which `y` belongs to which of the three stages.

```julia
using Clp
using JuMP
using SDDP

p = SDDP.LinearPolicyGraph(
    stages = 3,
    sense = :Max,
    upper_bound = 0
) do sp, node
    @variable(sp, x, SDDP.State, initial_value=0)  
    @variable(sp, y <= 10)
    @stageobjective(sp, y)
end

deq = SDDP.deterministic_equivalent(p)
set_optimizer(deq, Clp.Optimizer)
set_silent(deq)
optimize!(deq)

results = Dict(v => value(v) for v in all_variables(deq))
display(results)

# Dict{VariableRef, Float64} with 12 entries:
#  x_out => 0.0
#  y     => 10.0
#  _[12] => 0.0
#  y     => 10.0
#  x_out => 0.0
#  _[4]  => 0.0
#  x_in  => 0.0
#  y     => 10.0
#  x_in  => 0.0
#  _[8]  => 0.0
#  x_in  => 0.0
 # x_out => 0.0

```

My proposal is to append node indexes to the names of the deterministic equivalent variables. In this proposal, the `result` dictionary would end up with the stage after a `#` symbol (for a linear policy):

```julia
# Dict{VariableRef, Float64} with 12 entries:
#  x_in#1  => 0.0
#  y#2     => 10.0
#  x_in#3  => 0.0
#  #2      => 0.0
#  x_in#2  => 0.0
#  x_out#3 => 0.0
#  x_out#1 => 0.0
#  y#3     => 10.0
#  #3      => 0.0
#  y#1     => 10.0
#  x_out#2 => 0.0
#  #1      => 0.0
```
