### PR TITLE
Fix default stage objective

### DIFF
--- a/src/user_interface.jl
+++ b/src/user_interface.jl
@@ -659,7 +659,7 @@ function PolicyGraph(
             Noise[],
             (ω) -> nothing,
             Dict{Symbol,State{JuMP.VariableRef}}(),
-            nothing,
+            0.0,
             false,
             # Delay initializing the bellman function until later so that it can
             # use information about the children and number of

--- a/test/user_interface.jl
+++ b/test/user_interface.jl
@@ -671,6 +671,22 @@ function test_initial_feasibility()
     return
 end
 
+function test_no_stage_objective()
+    model = SDDP.LinearPolicyGraph(
+        stages = 2,
+        optimizer = HiGHS.Optimizer,
+        lower_bound = 0.0,
+    ) do sp, t
+        @variable(sp, x, SDDP.State, initial_value = 1.0)
+        @constraint(sp, x.in == x.out)
+    end
+    @test model[1].stage_objective == 0.0
+    @test model[2].stage_objective == 0.0
+    SDDP.train(model; iteration_limit = 3, print_level = 0)
+    @test SDDP.calculate_bound(model) ≈ 0.0 atol = 1e-8
+    return
+end
+
 end  # module
 
 TestUserInterface.runtests()


### PR DESCRIPTION
Part of #518.

I don't know why I chose the default to `nothing`. It really should be `0.0`. This now means that forgetting to set a stage objective no longer throws a `No method matching +(::Nothing, ::VariableRef)` error.