### PR TITLE
Revert "Try to recover if we need dual solutions (#531)"

### DIFF
--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -356,10 +356,6 @@ function _uninitialize_solver(model::PolicyGraph; throw_error::Bool)
     return
 end
 
-# Internal function: decide whether we need a feasible dual point
-needs_duals(duality_handler::Nothing) = false
-needs_duals(duality_handler::AbstractDualityHandler) = true
-
 # Internal function: solve the subproblem associated with node given the
 # incoming state variables state and realization of the stagewise-independent
 # noise term noise.
@@ -403,9 +399,6 @@ function solve_subproblem(
         throw(InterruptException())
     end
     if JuMP.primal_status(node.subproblem) != JuMP.MOI.FEASIBLE_POINT
-        attempt_numerical_recovery(model, node)
-    elseif needs_duals(duality_handler) &&
-           JuMP.dual_status(node.subproblem) != JuMP.MOI.FEASIBLE_POINT
         attempt_numerical_recovery(model, node)
     end
     state = get_outgoing_state(node)


### PR DESCRIPTION
This reverts commit 2eb30feaa18e551010398e55e4a8c59b1fbe8723.

@bfpc I'm reverting #531 because it doesn't account for cases with integer variables (so no dual solution will be present).

The place to fix it is probably here:

https://github.com/odow/SDDP.jl/blob/ed85827e85895ae7f3233d13a8bc4836db4fb56a/src/plugins/duality_handlers.jl#L112-L119

but that can be a separate PR.