### PR TITLE
Fix caching state bug in cyclic forward passes

### DIFF
--- a/src/plugins/forward_passes.jl
+++ b/src/plugins/forward_passes.jl
@@ -106,8 +106,8 @@ function forward_pass(
         # states for that node:
         starting_states = options.starting_states[final_node_index]
         # We also need the incoming state variable to the final node, which is
-        # the outgoing state value of the last node:
-        incoming_state_value = sampled_states[end]
+        # the outgoing state value of the second to last node:
+        incoming_state_value = sampled_states[end-1]
         # If this incoming state value is more than δ away from another state,
         # add it to the list.
         if distance(starting_states, incoming_state_value) >

--- a/test/plugins/forward_passes.jl
+++ b/test/plugins/forward_passes.jl
@@ -166,7 +166,7 @@ function test_RiskAdjustedForwardPass()
     return
 end
 
-function test_DefaultForwardPass()
+function test_DefaultForwardPass_cyclic()
     graph = SDDP.LinearGraph(3)
     SDDP.add_edge(graph, 3 => 1, 0.9)
     model = SDDP.PolicyGraph(
@@ -181,6 +181,7 @@ function test_DefaultForwardPass()
             return JuMP.set_upper_bound(x.out, ω)
         end
     end
+    pass = SDDP.DefaultForwardPass()
     options = SDDP.Options(
         model,
         Dict(:x => 1.0),
@@ -196,16 +197,101 @@ function test_DefaultForwardPass()
         SDDP.Log[],
         IOBuffer(),
         1,
-        SDDP.DefaultForwardPass(),
+        pass,
         SDDP.ContinuousConicDuality(),
         x -> nothing,
     )
-    forward_trajectory = SDDP.forward_pass(
-        model,
-        options,
-        SDDP.DefaultForwardPass(),
-    )
+    forward_trajectory = SDDP.forward_pass(model, options, pass)
+    @test length(forward_trajectory.scenario_path) == 4
+    @test length(forward_trajectory.sampled_states) == 4
     @test options.starting_states[1] == [Dict(:x => 4.5)]
+    @test isempty(options.starting_states[2])
+    @test isempty(options.starting_states[3])
+    return
+end
+
+function test_DefaultForwardPass_cyclic_include_last_node()
+    graph = SDDP.LinearGraph(3)
+    SDDP.add_edge(graph, 3 => 1, 0.9)
+    model = SDDP.PolicyGraph(
+        graph;
+        sense = :Max,
+        upper_bound = 100.0,
+        optimizer = HiGHS.Optimizer,
+    ) do node, stage
+        @variable(node, x, SDDP.State, initial_value = 0.0)
+        @stageobjective(node, x.out)
+        SDDP.parameterize(node, stage * [1.5]) do ω
+            return JuMP.set_upper_bound(x.out, ω)
+        end
+    end
+    pass = SDDP.DefaultForwardPass(include_last_node = false)
+    options = SDDP.Options(
+        model,
+        Dict(:x => 1.0),
+        SDDP.InSampleMonteCarlo(terminate_on_cycle = true),
+        SDDP.CompleteSampler(),
+        SDDP.Expectation(),
+        0.0,
+        true,
+        SDDP.AbstractStoppingRule[],
+        (a, b) -> nothing,
+        0,
+        0.0,
+        SDDP.Log[],
+        IOBuffer(),
+        1,
+        pass,
+        SDDP.ContinuousConicDuality(),
+        x -> nothing,
+    )
+    forward_trajectory = SDDP.forward_pass(model, options, pass)
+    @test length(forward_trajectory.scenario_path) == 3
+    @test length(forward_trajectory.sampled_states) == 3
+    @test options.starting_states[1] == [Dict(:x => 4.5)]
+    @test isempty(options.starting_states[2])
+    @test isempty(options.starting_states[3])
+    return
+end
+
+function test_DefaultForwardPass_acyclic_include_last_node()
+    graph = SDDP.LinearGraph(3)
+    model = SDDP.PolicyGraph(
+        graph;
+        sense = :Max,
+        upper_bound = 100.0,
+        optimizer = HiGHS.Optimizer,
+    ) do node, stage
+        @variable(node, x, SDDP.State, initial_value = 0.0)
+        @stageobjective(node, x.out)
+        SDDP.parameterize(node, stage * [1.5]) do ω
+            return JuMP.set_upper_bound(x.out, ω)
+        end
+    end
+    pass = SDDP.DefaultForwardPass(include_last_node = false)
+    options = SDDP.Options(
+        model,
+        Dict(:x => 1.0),
+        SDDP.InSampleMonteCarlo(terminate_on_cycle = true),
+        SDDP.CompleteSampler(),
+        SDDP.Expectation(),
+        0.0,
+        true,
+        SDDP.AbstractStoppingRule[],
+        (a, b) -> nothing,
+        0,
+        0.0,
+        SDDP.Log[],
+        IOBuffer(),
+        1,
+        pass,
+        SDDP.ContinuousConicDuality(),
+        x -> nothing,
+    )
+    forward_trajectory = SDDP.forward_pass(model, options, pass)
+    @test length(forward_trajectory.scenario_path) == 3
+    @test length(forward_trajectory.sampled_states) == 3
+    @test isempty(options.starting_states[1])
     @test isempty(options.starting_states[2])
     @test isempty(options.starting_states[3])
     return


### PR DESCRIPTION
I think there was a very subtle bug in the implementation of the cyclic state-drop-off logic. We should be storing the outgoing state of the second-to-last node (which will be the incoming state of the node that forms a cycle), not the outgoing state of the node that forms a cycle.

Then JADE should use historical inflows which are 52weeks + 1week long and things should work by default.

We could potentially improve things by removing the `splice!`, so that we build up a distribution of starting states, not the trajectory over time.

Closes #445 