### PR TITLE
Remove numerical issue warning

### DIFF
--- a/docs/src/tutorial/warnings.jl
+++ b/docs/src/tutorial/warnings.jl
@@ -58,14 +58,6 @@ end                         #hide
 #  - Subproblems turning infeasible or unbounded after many iterations
 #  - Solvers returning "Numerical Error" statuses
 
-# ### Attempting to recover from serious numerical issues...
-
-# `SDDP.jl` will try hard to avoid and overcome numerical issues. If it
-# encounters issues, you may see the warning `Attempting to recover from serious
-# numerical issues...`. If you see this warning multiple times, you should try
-# to follow the suggestions in this tutorial to improve the stability of your
-# model.
-
 # ### Problem scaling
 
 # In almost all cases, the cause of this is poor problem scaling. For our

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -236,13 +236,16 @@ function write_subproblem_to_file(
     MOI.write_to_file(model, filename)
     if throw_error
         error(
-            "Unable to retrieve solution from $(node.index).\n",
-            "  Termination status: $(JuMP.termination_status(node.subproblem))\n",
-            "  Primal status:      $(JuMP.primal_status(node.subproblem))\n",
-            "  Dual status:        $(JuMP.dual_status(node.subproblem)).\n",
-            "A MathOptFormat file was written to `$(filename)`.\n",
-            "See https://odow.github.io/SDDP.jl/latest/tutorial/06_warnings/#Numerical-stability-1",
-            "\nfor more information.",
+            "Unable to retrieve solution from node $(node.index).\n\n",
+            "  Termination status : $(JuMP.termination_status(node.subproblem))\n",
+            "  Primal status      : $(JuMP.primal_status(node.subproblem))\n",
+            "  Dual status        : $(JuMP.dual_status(node.subproblem)).\n\n",
+            "The current subproblem was written to `$(filename)`.\n\n",
+            "There are two common causes of this error:\n",
+            "  1) you have a mistake in your formulation, or you violated\n",
+            "     the assumption of relatively complete recourse\n",
+            "  2) the solver encountered numerical issues\n\n",
+            "See https://odow.github.io/SDDP.jl/stable/tutorial/warnings/ for more information.",
         )
     end
     return

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -260,7 +260,6 @@ function parameterize(node::Node, noise)
 end
 
 function attempt_numerical_recovery(model::PolicyGraph, node::Node)
-    @warn("Attempting to recover from serious numerical issues...")
     if JuMP.mode(node.subproblem) == JuMP.DIRECT
         @warn(
             "Unable to recover in direct mode! Remove `direct = true` when " *

--- a/test/algorithm.jl
+++ b/test/algorithm.jl
@@ -156,15 +156,21 @@ function test_infeasible_model()
     end
     ex = ErrorException(
         """
-Unable to retrieve solution from 1.
-  Termination status: INFEASIBLE
-  Primal status:      NO_SOLUTION
-  Dual status:        NO_SOLUTION.
-A MathOptFormat file was written to `subproblem_1.mof.json`.
-See https://odow.github.io/SDDP.jl/latest/tutorial/06_warnings/#Numerical-stability-1
-for more information.""",
-    )
+Unable to retrieve solution from node 1.
 
+  Termination status : INFEASIBLE
+  Primal status      : NO_SOLUTION
+  Dual status        : NO_SOLUTION.
+
+The current subproblem was written to `subproblem_1.mof.json`.
+
+There are two common causes of this error:
+  1) you have a mistake in your formulation, or you violated
+     the assumption of relatively complete recourse
+  2) the solver encountered numerical issues
+
+See https://odow.github.io/SDDP.jl/stable/tutorial/warnings/ for more information.""",
+    )
     @test_throws ex SDDP.train(model; iteration_limit = 1, print_level = 0)
     @test isfile("subproblem_1.mof.json")
     rm("subproblem_1.mof.json")
@@ -184,15 +190,21 @@ function test_infeasible_direct_model()
     end
     ex = ErrorException(
         """
-Unable to retrieve solution from 1.
-  Termination status: INFEASIBLE
-  Primal status:      NO_SOLUTION
-  Dual status:        NO_SOLUTION.
-A MathOptFormat file was written to `subproblem_1.mof.json`.
-See https://odow.github.io/SDDP.jl/latest/tutorial/06_warnings/#Numerical-stability-1
-for more information.""",
-    )
+Unable to retrieve solution from node 1.
 
+  Termination status : INFEASIBLE
+  Primal status      : NO_SOLUTION
+  Dual status        : NO_SOLUTION.
+
+The current subproblem was written to `subproblem_1.mof.json`.
+
+There are two common causes of this error:
+  1) you have a mistake in your formulation, or you violated
+     the assumption of relatively complete recourse
+  2) the solver encountered numerical issues
+
+See https://odow.github.io/SDDP.jl/stable/tutorial/warnings/ for more information.""",
+    )
     @test_throws ex SDDP.train(model; iteration_limit = 1, print_level = 0)
     @test isfile("subproblem_1.mof.json")
     rm("subproblem_1.mof.json")


### PR DESCRIPTION
I think this is doing more harm than good.

@rafabench added it to the log in https://github.com/odow/SDDP.jl/pull/586, so expert users can still find what they're looking for.

But it confuses new users when the subproblem is actually infeasible, like https://github.com/odow/SDDP.jl/issues/626, and someone who emailed me today.