### PR TITLE
Fix bug in MSPFormat reader

### DIFF
--- a/src/MSPFormat.jl
+++ b/src/MSPFormat.jl
@@ -35,7 +35,8 @@ function _parse_lattice(filename::String)
     return graph, data
 end
 
-_get_constant(terms::String, state::Dict) = state[terms]
+# Use a default of 0.0 for any missing keys.
+_get_constant(terms::String, state::Dict) = get(state, terms, 0.0)
 _get_constant(::String, ::Nothing) = nothing
 _get_constant(key::Number, ::Union{Dict,Nothing}) = key
 

--- a/test/MSPFormat.jl
+++ b/test/MSPFormat.jl
@@ -59,6 +59,7 @@ function test_get_constant()
         Any[Dict("ADD" => "inflow"), Dict("MUL" => -1.0), Dict("MUL" => 0.5)]
     @test MSPFormat._get_constant(terms) === terms
     @test MSPFormat._get_constant(terms, state) === -6.0
+    @test MSPFormat._get_constant("bad_inflow", state) === 0.0
     return
 end
 


### PR DESCRIPTION
Closes #637

I didn't test, but it seems like this is the likely culprit.

@bonnkleiford You can install this branch with:
```
] add SDDP#od/fix-msp-format
```