### PR TITLE
[docs] update Two-stage newsvendor example

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -15,6 +15,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 SDDP = "f4570300-c277-11e8-125c-4912f86ce65d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -27,3 +28,4 @@ JuMP = "1.11.1"
 Literate = "2"
 Plots = "1"
 PowerModels = "0.19"
+StatsPlots = "0.15"

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -3,10 +3,13 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this  #src
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.             #src
 
-# # Two-stage stochastic programs
+# # Example: Two-stage Newsvendor
 
 # The purpose of this tutorial is to demonstrate how to model and solve a
 # two-stage stochastic program.
+
+# It is based on the [Two stage stochastic programs](https://jump.dev/JuMP.jl/dev/tutorials/applications/two_stage_stochastic/)
+# tutorial in JuMP.
 
 # This tutorial uses the following packages
 
@@ -20,48 +23,7 @@ import Statistics
 
 # ## Background
 
-# During the week, you are a busy practitioner of Operations Research. To escape
-# the drudgery of mathematics, you decide to invest in a food truck that you
-# park at a popular park on a Saturday afternoon. Your delicacy of choice is
-# a creamy mushroom pie with puff pastry. After a few weeks, it quickly becomes
-# apparent that operating a food business is not so easy.
-
-# The pies must be prepared on a Saturday morning, _before_ you arrive at the
-# location and can gauge the level of demand. If you bake too many, the unsold
-# pies at the end of the day must be discarded and you have wasted time and
-# money on their production. But if you bake too few, then there may be
-# un-served customers and you could have made more money by baking more pies.
-
-# After a few weeks of poor decision making, you decide to put your knowledge of
-# Operations Research to good use, starting with some data collection.
-
-# Each pie costs you \$2 to make, and you sell them at \$5 each. Disposal of an
-# unsold pie costs \$0.10. Based on three weeks of data collected, in which you
-# made 200 pies each week, you sold 150, 190, and 200 pies. Thus, as a guess,
-# you assume a triangular distribution of demand with a minimum of 150, a median
-# of 200, and a maximum of 250.
-
-# We can model this problem by a two-stage stochastic program. In the first
-# stage, we decide a quantity of pies to make ``x``. We make this decision
-# before we observe the demand ``d_\omega``. In the second stage, we sell
-# ``y_\omega`` pies, and incur any costs for unsold pies.
-
-# We can formulate this problem as follows:
-# ```math
-# \begin{aligned}
-# \max\limits_{x,y_\omega} \;\; & -2x + \mathbb{E}_\omega[5y_\omega - 0.1(x - y_\omega)] \\
-#   & y_\omega \le x              & \quad \forall \omega \in \Omega \\
-#   & 0 \le y_\omega \le d_\omega & \quad \forall \omega \in \Omega \\
-#   & x \ge 0.
-# \end{aligned}
-# ```
-
-# ## Sample Average approximation
-
-# If the distribution of demand is continuous, then our problem has an infinite
-# number of variables and constraints. To form a computationally tractable
-# problem, we instead use a finite set of samples drawn from the distribution.
-# This is called sample average approximation (SAA).
+# The data for this problem is:
 
 D = Distributions.TriangularDist(150.0, 250.0, 200.0)
 N = 100
@@ -69,174 +31,6 @@ d = sort!(rand(D, N));
 Ω = 1:N
 P = fill(1 / N, N);
 StatsPlots.histogram(d; bins = 20, label = "", xlabel = "Demand")
-
-# ## JuMP model
-
-# The implementation of our two-stage stochastic program in JuMP is:
-
-model = Model(HiGHS.Optimizer)
-set_silent(model)
-@variable(model, x >= 0)
-@variable(model, 0 <= y[ω in Ω] <= d[ω])
-@constraint(model, [ω in Ω], y[ω] <= x)
-@expression(model, z[ω in Ω], 5y[ω] - 0.1 * (x - y[ω]))
-@objective(model, Max, -2x + sum(P[ω] * z[ω] for ω in Ω))
-optimize!(model)
-solution_summary(model)
-
-# The optimal number of pies to make is:
-
-value(x)
-
-# The distribution of total profit is:
-
-total_profit = [-2 * value(x) + value(z[ω]) for ω in Ω]
-
-# Let's plot it:
-
-"""
-    bin_distribution(x::Vector{Float64}, N::Int)
-
-A helper function that discretizes `x` into bins of width `N`.
-"""
-bin_distribution(x, N) = N * (floor(minimum(x) / N):ceil(maximum(x) / N))
-
-plot = StatsPlots.histogram(
-    total_profit;
-    bins = bin_distribution(total_profit, 25),
-    label = "",
-    xlabel = "Profit [\$]",
-    ylabel = "Number of outcomes",
-)
-μ = Statistics.mean(total_profit)
-Plots.vline!(
-    plot,
-    [μ];
-    label = "Expected profit (\$$(round(Int, μ)))",
-    linewidth = 3,
-)
-plot
-
-# ## Exercises
-
-#  * Try solving this problem for different numbers of samples and different
-#    distributions.
-#  * Refactor the example to avoid hard-coding the costs. What happens to the
-#    solution if the cost of disposing unsold pies increases?
-
-# ## Risk measures
-
-# A risk measure is a function which maps a random variable to a real number.
-# Common risk measures include the mean (expectation), median, mode, and
-# maximum. We need a risk measure to convert the distribution of second stage
-# costs into a single number that can be optimized.
-
-# Our model currently uses the expectation risk measure, but others are possible
-# too. One popular risk measure is the conditional value at risk (CVaR).
-
-# CVaR has a parameter $\gamma$, and it computes the expectation of the worst
-# $\gamma$ fraction of outcomes.
-
-# If we are maximizing, so that small outcomes are bad, the definition of CVaR
-# is:
-# ```math
-# CVaR_{\gamma}[Z] = \max\limits_{\xi} \;\; \xi - \frac{1}{\gamma}\mathbb{E}_\omega\left[(\xi - Z)_+\right]
-# ```
-# which can be formulated as the linear program:
-# ```math
-# \begin{aligned}
-# CVaR_{\gamma}[Z] = \max\limits_{\xi, z_\omega} \;\; & \xi - \frac{1}{\gamma}\sum P_\omega z_\omega\\
-#  & z_\omega \ge \xi - Z_\omega & \quad \forall \omega \\
-#  & z_\omega \ge 0 & \quad \forall \omega.
-# \end{aligned}
-# ```
-
-function CVaR(Z::Vector{Float64}, P::Vector{Float64}; γ::Float64)
-    @assert 0 < γ <= 1
-    N = length(Z)
-    model = Model(HiGHS.Optimizer)
-    set_silent(model)
-    @variable(model, ξ)
-    @variable(model, z[1:N] >= 0)
-    @constraint(model, [i in 1:N], z[i] >= ξ - Z[i])
-    @objective(model, Max, ξ - 1 / γ * sum(P[i] * z[i] for i in 1:N))
-    optimize!(model)
-    return objective_value(model)
-end
-
-# When `γ` is `1.0`, we compute the mean of the profit:
-
-cvar_10 = CVaR(total_profit, P; γ = 1.0)
-
-#-
-
-Statistics.mean(total_profit)
-
-# As `γ` approaches `0.0`, we compute the worst-case (minimum) profit:
-
-cvar_00 = CVaR(total_profit, P; γ = 0.0001)
-
-#-
-
-minimum(total_profit)
-
-# By varying `γ` between `0` and `1` we can compute some trade-off of these two
-# extremes:
-
-cvar_05 = CVaR(total_profit, P; γ = 0.5)
-
-# Let's plot these outcomes on our distribution:
-
-plot = StatsPlots.histogram(
-    total_profit;
-    bins = bin_distribution(total_profit, 25),
-    label = "",
-    xlabel = "Profit [\$]",
-    ylabel = "Number of outcomes",
-)
-Plots.vline!(
-    plot,
-    [cvar_10 cvar_05 cvar_00];
-    label = ["γ = 1.0" "γ = 0.5" "γ = 0.0"],
-    linewidth = 3,
-)
-plot
-
-# ## Risk averse sample average approximation
-
-# Because CVaR can be formulated as a linear program, we can form a risk averse
-# sample average approximation model by combining the two formulations:
-
-γ = 0.4
-model = Model(HiGHS.Optimizer)
-set_silent(model)
-@variable(model, x >= 0)
-@variable(model, 0 <= y[ω in Ω] <= d[ω])
-@constraint(model, [ω in Ω], y[ω] <= x)
-@expression(model, Z[ω in Ω], 5 * y[ω] - 0.1(x - y[ω]))
-@variable(model, ξ)
-@variable(model, z[ω in Ω] >= 0)
-@constraint(model, [ω in Ω], z[ω] >= ξ - Z[ω])
-@objective(model, Max, -2x + ξ - 1 / γ * sum(P[ω] * z[ω] for ω in Ω))
-optimize!(model)
-
-# When ``\gamma = 0.4``, the optimal number of pies to bake is:
-
-value(x)
-
-# The distribution of total profit is:
-
-risk_averse_total_profit = [value(-2x + Z[ω]) for ω in Ω]
-bins = bin_distribution([total_profit; risk_averse_total_profit], 25)
-plot = StatsPlots.histogram(total_profit; label = "Expectation", bins = bins)
-StatsPlots.histogram!(
-    plot,
-    risk_averse_total_profit;
-    label = "CV@R",
-    bins = bins,
-    alpha = 0.5,
-)
-plot
 
 # ## Policy Graph
 
@@ -252,15 +46,18 @@ graph = SDDP.LinearGraph(2)
 function build_subproblem(subproblem::JuMP.Model, stage::Int)
     @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
     if stage == 1
-        @stageobjective(subproblem, -2 * x.out)
+        @variable(subproblem, u_make >= 0)
+        @constraint(subproblem, x.out == x.in + u_make)
+        @stageobjective(subproblem, -2 * u_make)
     else
-        @variable(subproblem, y >= 0)
-        @constraint(subproblem, y <= x.in)
+        @variable(subproblem, u_sell >= 0)
+        @constraint(subproblem, u_sell <= x.in)
+        @constraint(subproblem, x.out == x.in - u_sell)
         SDDP.parameterize(subproblem, d, P) do ω
-            set_upper_bound(y, ω)
+            set_upper_bound(u_sell, ω)
             return
         end
-        @stageobjective(subproblem, 5 * y - 0.1 * (x.in - y))
+        @stageobjective(subproblem, 5 * u_sell - 0.1 * x.out)
     end
     return
 end
@@ -288,7 +85,7 @@ first_stage_rule = SDDP.DecisionRule(model, node = 1)
 
 solution = SDDP.evaluate(first_stage_rule; incoming_state = Dict(:x => 0.0))
 
-# The optimal value of the `buy` variable is stored here:
+# The optimal value of the state variable is stored here:
 
 solution.outgoing_state[:x]
 
@@ -312,18 +109,58 @@ model = SDDP.LinearPolicyGraph(;
 ) do subproblem::JuMP.Model, stage::Int
     @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
     if stage == 1
-        @stageobjective(subproblem, -2 * x.out)
+        @variable(subproblem, u_make >= 0)
+        @constraint(subproblem, x.out == x.in + u_make)
+        @stageobjective(subproblem, -2 * u_make)
     else
-        @variable(subproblem, y >= 0)
-        @constraint(subproblem, y <= x.in)
+        @variable(subproblem, u_sell >= 0)
+        @constraint(subproblem, u_sell <= x.in)
+        @constraint(subproblem, x.out == x.in - u_sell)
         SDDP.parameterize(subproblem, d, P) do ω
-            set_upper_bound(y, ω)
+            set_upper_bound(u_sell, ω)
             return
         end
-        @stageobjective(subproblem, 5 * y - 0.1 * (x.in - y))
+        @stageobjective(subproblem, 5 * u_sell - 0.1 * x.out)
     end
     return
 end
+
+# ## Simulation
+
+# Querying the decision rules is tedious. It's often more useful to simulate the
+# policy:
+
+SDDP.train(model)
+simulations = SDDP.simulate(
+    model,
+    10,  #= number of replications =#
+    [:x, :u_sell, :u_buy];  #= variables to record =#
+    skip_undefined_variables = true,
+);
+
+# `simulations` is a vector with 10 elements
+
+length(simulations)
+
+# and each element is a vector with two elements (one for each stage)
+
+length(simulations[1])
+
+# The first stage contains:
+
+simulations[1][1]
+
+# The second stage contains:
+
+simulations[1][2]
+
+# We can compute aggregated statistics across the simulations:
+
+objectives = map(simulations) do simulation
+    return sum(data[:stage_objective] for data in simulation)
+end
+μ, t = SDDP.confidence_interval(objectives)
+println("Simulation ci : $μ ± $t")
 
 # ## Risk aversion revisited
 
@@ -343,18 +180,19 @@ function solve_newsvendor(risk_measure::SDDP.AbstractRiskMeasure)
         sense = :Max,
         upper_bound = 5 * maximum(d),
         optimizer = HiGHS.Optimizer,
-    ) do subproblem, stage
+    ) do subproblem, node
         @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
-        if stage == 1
+        if node == 1
             @stageobjective(subproblem, -2 * x.out)
         else
-            @variable(subproblem, y >= 0)
-            @constraint(subproblem, y <= x.in)
+            @variable(subproblem, u_sell >= 0)
+            @constraint(subproblem, u_sell <= x.in)
+            @constraint(subproblem, x.out == x.in - u_sell)
             SDDP.parameterize(subproblem, d, P) do ω
-                set_upper_bound(y, ω)
+                set_upper_bound(u_sell, ω)
                 return
             end
-            @stageobjective(subproblem, 5 * y - 0.1 * (x.in - y))
+            @stageobjective(subproblem, 5 * u_sell - 0.1 * x.out)
         end
         return
     end
@@ -402,3 +240,76 @@ Plots.plot(
 #  * What happens if you can only buy and sell integer numbers of newspapers?
 #    Try this by adding `Int` to the variable definitions:
 #    `@variable(subproblem, buy >= 0, Int)`
+
+# ## Other graphs
+
+# The two-stage newsvendor problem can be extended to other graphs. For example,
+# here is a three-stage graph:
+
+graph = SDDP.Graph(:root)
+SDDP.add_node(graph, :make_only)
+SDDP.add_node(graph, :sell_only)
+SDDP.add_node(graph, :make_and_sell)
+SDDP.add_edge(graph, :root => :make_only, 1.0)
+SDDP.add_edge(graph, :make_only => :make_and_sell, 1.0)
+SDDP.add_edge(graph, :make_and_sell => :sell_only, 1.0)
+graph
+
+# with the model formulation:
+
+model = SDDP.PolicyGraph(
+    graph;
+    sense = :Max,
+    upper_bound = 2 * 5 * maximum(d),
+    optimizer = HiGHS.Optimizer,
+) do subproblem::JuMP.Model, node::Symbol
+    @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
+    if node == :make_only
+        @variable(subproblem, u_make >= 0)
+        @constraint(subproblem, x.out == x.in + u_make)
+        @stageobjective(subproblem, -2 * u_make)
+    elseif node == :sell_only
+        @variable(subproblem, u_sell >= 0)
+        @constraint(subproblem, u_sell <= x.in)
+        @constraint(subproblem, x.out == x.in - u_sell)
+        SDDP.parameterize(subproblem, d, P) do ω
+            set_upper_bound(u_sell, ω)
+            return
+        end
+        @stageobjective(subproblem, 5 * u_sell - 0.1 * x.out)
+    else
+        @assert node == :make_and_sell
+        @variable(subproblem, u_sell >= 0)
+        @variable(subproblem, u_make >= 0)
+        @constraint(subproblem, u_sell <= x.in)
+        @constraint(subproblem, x.out == x.in - u_sell + u_make)
+        SDDP.parameterize(subproblem, d, P) do ω
+            set_upper_bound(u_sell, ω)
+            return
+        end
+        @stageobjective(subproblem, 5 * u_sell - 0.1 * x.out - 2 * u_make)
+    end
+    return
+end
+
+SDDP.train(model)
+simulations = SDDP.simulate(
+    model,
+    10,  #= number of replications =#
+    [:x, :u_sell, :u_buy];  #= variables to record =#
+    skip_undefined_variables = true,
+);
+
+#-
+
+simulations[1][1]
+
+#-
+
+simulations[1][2]
+
+#-
+
+simulations[1][3]
+
+# Try changing the graph. What happens if you add a cycle?

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -55,7 +55,7 @@ import Statistics
 # x \ge 0.
 # \end{aligned}
 # ```
-# Note that we are minimizingn cost, so the profit from selling a pie is a
+# Note that we are minimizing cost, so the profit from selling a pie is a
 # negative cost.
 
 # ## Sample Average approximation
@@ -136,8 +136,8 @@ plot
 # Our model currently uses the expectation risk measure, but others are possible
 # too. One popular risk measure is the conditional value at risk (CVaR).
 
-# CVaR has a parameter $\gamma$. Thhe risk measure computes the expectation of
-# the worst $\gamma$ fraction of outcomes.
+# CVaR has a parameter $\gamma$, and it computes the expectation of the worst
+# $\gamma$ fraction of outcomes.
 
 # The definition of CVaR is:
 # ```math
@@ -248,7 +248,7 @@ plot
 
 graph = SDDP.LinearGraph(2)
 
-# Then, we need to write a function which builds a JuMP model for eachh node in
+# Then, we need to write a function which builds a JuMP model for each node in
 # the graph:
 
 function build_subproblem(subproblem::JuMP.Model, stage::Int)
@@ -304,7 +304,7 @@ model = SDDP.LinearPolicyGraph(
     optimizer = HiGHS.Optimizer,
 )
 
-# and we can use Julia's `do` syntax to avoid writing a separate functionn:
+# and we can use Julia's `do` syntax to avoid writing a separate function:
 
 model = SDDP.LinearPolicyGraph(;
     stages = 2,

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -3,47 +3,272 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this  #src
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.             #src
 
-# # Example: Two-stage Newsvendor
+# # Two-stage stochastic programs
 
-# This example is based on the classical newsvendor problem.
+# The purpose of this tutorial is to demonstrate how to model and solve a
+# two-stage stochastic program.
 
+# This tutorial uses the following packages
+
+using JuMP
 using SDDP
+import Distributions
 import HiGHS
 import Plots
+import StatsPlots
+import Statistics
 
-# First, we need some discretized distribution of demand. For simplicity, we're
-# going to sample 10 points from the uniform `[0, 1)` distribution three times
-# and add them together. This is a rough approximation of a normal distribution.
+# ## Background
 
-Ω = rand(10) .+ rand(10) .+ rand(10)
+# During the week, you are a busy practitioner of Operations Research. To escape
+# the drudgery of mathematics, you decide to invest in a food truck that you
+# park at a popular park on a Saturday afternoon. Your delicacy of choice is
+# a creamy mushroom pie with puff pastry. After a few weeks, it quickly becomes
+# apparent that operating a food business is not so easy.
 
-# We also need some price data. We assume the agent can buy a newspaper for \$1
-# and sell it for \$1.20.
+# The pies must be prepared on a Saturday morning, _before_ you arrive at the
+# location and can gauge the level of demand. If you bake too many, the unsold
+# pies at the end of the day must be discarded and you have wasted time and
+# money on their production. But if you bake too few, then there may be
+# un-served customers and you could have made more money by baking more pies.
 
-buy_price, sales_price = 1.0, 1.2
+# After a few weeks of poor decision making, you decide to put your knowledge of
+# Operations Research to good use, starting with some data collection.
 
-# Now we can formulate and train a policy for the two-stage newsvendor problem:
+# Each pie costs you $2 to make, and you sell them at $5 each. Disposal of an
+# unsold pie costs $0.10. Based on three weeks of data collected, in which you
+# made 200 pies each week, you sold 150, 190, and 200 pies. Thus, as a guess,
+# you assume a triangular distribution of demand with a minimum of 150, a median
+# of 200, and a maximum of 250.
 
-model = SDDP.LinearPolicyGraph(
-    stages = 2,
-    sense = :Max,
-    upper_bound = maximum(Ω) * sales_price,
-    optimizer = HiGHS.Optimizer,
-) do subproblem, stage
-    @variable(subproblem, inventory >= 0, SDDP.State, initial_value = 0)
-    if stage == 1
-        @variable(subproblem, buy >= 0)
-        @constraint(subproblem, inventory.out == inventory.in + buy)
-        @stageobjective(subproblem, -buy_price * buy)
-    else
-        @variable(subproblem, sell >= 0)
-        @constraint(subproblem, sell <= inventory.in)
-        SDDP.parameterize(subproblem, Ω) do ω
-            return JuMP.set_upper_bound(sell, ω)
-        end
-        @stageobjective(subproblem, sales_price * sell)
-    end
+# We can model this problem by a two-stage stochastic program. In the first
+# stage, we decide a quantity of pies to make ``x``. We make this decision
+# before we observe the demand ``d_\omega``. In the second stage, we sell
+# ``y_\omega`` pies, and incur any costs for unsold pies.
+
+# We can formulate this problem as follows:
+# ```math
+# \begin{aligned}
+# \min 2x + \mathbb{E}_\omega[-5y_\omega + 0.1(x - y_\omega)] \\
+# y_\omega \le x \quad \forall \omega \in \Omega \\
+# 0 \le y_\omega \le d_\omega \quad \forall \omega \in \Omega \\
+# x \ge 0.
+# \end{aligned}
+# ```
+# Note that we are minimizingn cost, so the profit from selling a pie is a
+# negative cost.
+
+# ## Sample Average approximation
+
+# If the distribution of demand is continuous, then our problem has an infinite
+# number of variables and constraints. To form a computationally tractable
+# problem, we instead use a finite set of samples drawn from the distribution.
+# This is called sample average approximation (SAA).
+
+D = Distributions.TriangularDist(150.0, 250.0, 200.0)
+N = 100
+d = sort!(rand(D, N));
+Ω = 1:N
+P = fill(1 / N, N);
+StatsPlots.histogram(d; bins = 20)
+
+# ## JuMP model
+
+# The implementation of our two-stage stochastic program in JuMP is:
+
+model = Model(HiGHS.Optimizer)
+set_silent(model)
+@variable(model, x >= 0)
+@variable(model, 0 <= y[ω in Ω] <= d[ω])
+@constraint(model, [ω in Ω], y[ω] <= x)
+@expression(model, z[ω in Ω], -5y[ω] + 0.1 * (x - y[ω]))
+@objective(model, Min, 2x + sum(P[ω] * z[ω] for ω in Ω))
+optimize!(model)
+solution_summary(model)
+
+# The optimal number of pies to make is:
+
+value(x)
+
+# The distribution of total profit is:
+
+total_cost = [2 * value(x) + value(z[ω]) for ω in Ω]
+
+bins = extrema(total_cost)
+plot = StatsPlots.histogram(
+    -total_cost;
+    bins = 20,
+    label = "",
+    xlabel = "Profit [\$]",
+    ylabel = "Number of outcomes",
+)
+μ = Statistics.mean(-total_cost)
+Plots.vline!(
+    plot,
+    [μ];
+    label = "Expected profit (\$$(round(Int, μ)))",
+    linewidth = 3,
+)
+
+# ## Exercises
+
+#  * Try solving this problem for different numbers of samples and different
+#    distributions.
+#  * Refactor the example to avoid hard-coding the costs. What happens to the
+#    solution if the cost of disposing unsold pies increases?
+
+# ## Risk measures
+
+# A risk measure is a function which maps a random variable to a real number.
+# Common risk measures include the mean (expectation), median, mode, and
+# maximum. We need a risk measure to convert the distribution of second stage
+# costs into a single number that can be optimized.
+
+# Our model currently uses the expectation risk measure, but others are possible
+# too. One popular risk measure is the conditional value at risk (CVaR).
+
+# CVaR has a parameter $\gamma$. Thhe risk measure computes the expectation of
+# the worst $\gamma$ fraction of outcomes.
+
+# The definition of CVaR is:
+# ```math
+# CVaR_{\gamma}[Z] = \min\limits_{\xi} \xi + \frac{1}{\gamma}\mathbb{E}_\omega[(Z - \xi)_+]
+# ```
+# which can be formulated as the linear program:
+# ```math
+# \begin{aligned}
+# CVaR_{\gamma}[Z] = \min \xi + \frac{1}{\gamma}\sum P_\omega z_\omega\\
+#  & z_\omega \ge Z_\omega - \xi \\
+#  & z_\omega \ge 0 \forall \omega
+# \end{aligned}
+# ```
+
+function CVaR(Z::Vector{Float64}, P::Vector{Float64}; γ::Float64)
+    @assert 0 < γ <= 1
+    N = length(Z)
+    model = Model(HiGHS.Optimizer)
+    set_silent(model)
+    @variable(model, ξ)
+    @variable(model, z[1:N] >= 0)
+    @constraint(model, [i in 1:N], z[i] >= Z[i] - ξ)
+    @objective(model, Min, ξ + 1 / γ * sum(P[i] * z[i] for i in 1:N))
+    optimize!(model)
+    return objective_value(model)
 end
+
+# When `γ` is `1.0`, we compute the mean of the cost:
+
+cvar_10 = CVaR(total_cost, P; γ = 1.0)
+
+#-
+
+Statistics.mean(total_cost)
+
+# As `γ` approaches `0.0`, we compute the worst-case (maximum) cost:
+
+cvar_00 = CVaR(total_cost, P; γ = 0.0001)
+
+#-
+
+maximum(total_cost)
+
+# By varying `γ` between `0` and `1` we can compute some trade-off of these two
+# extremes:
+
+cvar_05 = CVaR(total_cost, P; γ = 0.5)
+
+# Let's plot these outcomes on our distribution:
+
+plot = StatsPlots.histogram(
+    -total_cost;
+    bins = 20,
+    label = "",
+    xlabel = "Profit [\$]",
+    ylabel = "Number of outcomes",
+)
+Plots.vline!(
+    plot,
+    -[cvar_10 cvar_05 cvar_00];
+    label = ["γ = 1.0" "γ = 0.5" "γ = 0.0"],
+    linewidth = 3,
+)
+
+# ## Risk averse sample average approximation
+
+# Because CVaR can be formulated as a minimization linear program, we can form a
+# risk averse sample average approximation model by combining the two
+# formulations:
+
+γ = 0.4
+model = Model(HiGHS.Optimizer)
+set_silent(model)
+@variable(model, x >= 0)
+@variable(model, 0 <= y[ω in Ω] <= d[ω])
+@constraint(model, [ω in Ω], y[ω] <= x)
+@expression(model, Z[ω in Ω], -5 * y[ω] + 0.1(x - y[ω]))
+@variable(model, ξ)
+@variable(model, z[ω in Ω] >= 0)
+@constraint(model, [ω in Ω], z[ω] >= Z[ω] - ξ)
+@objective(model, Min, 2x + ξ + 1 / γ * sum(P[ω] * z[ω] for ω in Ω))
+optimize!(model)
+
+# When ``\gamma = 0.4``, the optimal number of pies to bake is:
+
+value(x)
+
+# The distribution of total profit is:
+
+risk_averse_total_profit = [-value(2x + Z[ω]) for ω in Ω]
+plot = StatsPlots.histogram(
+    -total_cost;
+    label = "Expectation",
+    bins = 300:25:650,
+)
+StatsPlots.histogram!(
+    risk_averse_total_profit;
+    label = "CV@R",
+    bins = 300:25:650,
+    alpha = 0.5,
+)
+
+# ## Policy Graph
+
+# Now we can formulate and train a policy for the two-stage newsvendor problem.
+
+# First, we need to construct the graph:
+
+graph = SDDP.LinearGraph(2)
+
+# Then, we need to write a function which builds a JuMP model for eachh node in
+# the graph:
+
+function build_subproblem(subproblem::JuMP.Model, stage::Int)
+    @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
+    if stage == 1
+        @stageobjective(subproblem, 2 * x.out)
+    else
+        @variable(subproblem, y >= 0)
+        @constraint(subproblem, y <= x.in)
+        SDDP.parameterize(subproblem, d, P) do ω
+            set_upper_bound(y, ω)
+            return
+        end
+        @stageobjective(subproblem, -5 * y + 0.1 * (x.in - y))
+    end
+    return
+end
+
+# Then, we can combine the graph and the subproblem builder into a policy graph:
+
+model = SDDP.PolicyGraph(
+    build_subproblem,
+    graph;
+    sense = :Min,
+    lower_bound = -5 * maximum(d),
+    optimizer = HiGHS.Optimizer,
+)
+
+# Use [`SDDP.train`](@ref) to construct the policy:
 
 SDDP.train(model)
 
@@ -56,13 +281,45 @@ first_stage_rule = SDDP.DecisionRule(model, node = 1)
 
 solution = SDDP.evaluate(
     first_stage_rule;
-    incoming_state = Dict(:inventory => 0.0),
-    controls_to_record = [:buy],
+    incoming_state = Dict(:x => 0.0),
 )
 
 # The optimal value of the `buy` variable is stored here:
 
-solution.controls[:buy]
+solution.outgoing_state[:x]
+
+# We can simplify the model construction by using [`SDDP.LinearPolicyGraph`](@ref):
+
+model = SDDP.LinearPolicyGraph(
+    build_subproblem;
+    stages = 2,
+    sense = :Min,
+    lower_bound = -5 * maximum(d),
+    optimizer = HiGHS.Optimizer,
+)
+
+# and we can use Julia's `do` syntax to avoid writing a separate functionn:
+
+model = SDDP.LinearPolicyGraph(;
+    stages = 2,
+    sense = :Min,
+    lower_bound = -5 * maximum(d),
+    optimizer = HiGHS.Optimizer,
+) do subproblem::JuMP.Model, stage::Int
+    @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
+    if stage == 1
+        @stageobjective(subproblem, 2 * x.out)
+    else
+        @variable(subproblem, y >= 0)
+        @constraint(subproblem, y <= x.in)
+        SDDP.parameterize(subproblem, d, P) do ω
+            set_upper_bound(y, ω)
+            return
+        end
+        @stageobjective(subproblem, -5 * y + 0.1 * (x.in - y))
+    end
+    return
+end
 
 # ## Introducing risk
 
@@ -74,44 +331,43 @@ solution.controls[:buy]
 # We can explore how the optimal decision changes with risk by creating a
 # function:
 
-function solve_risk_averse_newsvendor(Ω, risk_measure)
+function solve_risk_averse_newsvendor(risk_measure)
     model = SDDP.LinearPolicyGraph(
         stages = 2,
-        sense = :Max,
-        upper_bound = maximum(Ω) * sales_price,
+        sense = :Min,
+        lower_bound = -5 * maximum(d),
         optimizer = HiGHS.Optimizer,
     ) do subproblem, stage
-        @variable(subproblem, inventory >= 0, SDDP.State, initial_value = 0)
+        @variable(subproblem, x >= 0, SDDP.State, initial_value = 0)
         if stage == 1
-            @variable(subproblem, buy >= 0)
-            @constraint(subproblem, inventory.out == inventory.in + buy)
-            @stageobjective(subproblem, -buy_price * buy)
+            @stageobjective(subproblem, 2 * x.out)
         else
-            @variable(subproblem, sell >= 0)
-            @constraint(subproblem, sell <= inventory.in)
-            SDDP.parameterize(subproblem, Ω) do ω
-                return JuMP.set_upper_bound(sell, ω)
+            @variable(subproblem, y >= 0)
+            @constraint(subproblem, y <= x.in)
+            SDDP.parameterize(subproblem, d, P) do ω
+                set_upper_bound(y, ω)
+                return
             end
-            @stageobjective(subproblem, sales_price * sell)
+            @stageobjective(subproblem, -5 * y + 0.1 * (x.in - y))
         end
+        return
     end
     SDDP.train(model; risk_measure = risk_measure, print_level = 0)
-    first_stage_rule = SDDP.DecisionRule(model, node = 1)
+    first_stage_rule = SDDP.DecisionRule(model; node = 1)
     solution = SDDP.evaluate(
         first_stage_rule;
-        incoming_state = Dict(:inventory => 0.0),
-        controls_to_record = [:buy],
+        incoming_state = Dict(:x => 0.0),
     )
-    return solution.controls[:buy]
+    return solution.outgoing_state[:x]
 end
 
 # Now we can see how many units a risk-neutral decision maker would order:
 
-solve_risk_averse_newsvendor(Ω, SDDP.Expectation())
+solve_risk_averse_newsvendor(SDDP.AVaR(0.4))
 
 # as well as a decision-maker who cares only about the worst-case outcome:
 
-solve_risk_averse_newsvendor(Ω, SDDP.WorstCase())
+solve_risk_averse_newsvendor(SDDP.WorstCase())
 
 # In general, the decision-maker will be somewhere between the two extremes.
 # The [`SDDP.Entropic`](@ref) risk measure is a risk measure that has a single
@@ -122,8 +378,8 @@ solve_risk_averse_newsvendor(Ω, SDDP.WorstCase())
 # Here is what we get if we solve our problem multiple times for different
 # values of the risk aversion parameter ``\gamma``:
 
-Γ = [10^i for i in -3:0.2:3]
-buy = [solve_risk_averse_newsvendor(Ω, SDDP.Entropic(γ)) for γ in Γ]
+Γ = [10^i for i in -5:0.5:2]
+buy = [solve_risk_averse_newsvendor(SDDP.Entropic(γ)) for γ in Γ]
 Plots.plot(
     Γ,
     buy;

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -35,8 +35,8 @@ import Statistics
 # After a few weeks of poor decision making, you decide to put your knowledge of
 # Operations Research to good use, starting with some data collection.
 
-# Each pie costs you $2 to make, and you sell them at $5 each. Disposal of an
-# unsold pie costs $0.10. Based on three weeks of data collected, in which you
+# Each pie costs you \$2 to make, and you sell them at \$5 each. Disposal of an
+# unsold pie costs \$0.10. Based on three weeks of data collected, in which you
 # made 200 pies each week, you sold 150, 190, and 200 pies. Thus, as a guess,
 # you assume a triangular distribution of demand with a minimum of 150, a median
 # of 200, and a maximum of 250.

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -131,10 +131,13 @@ end
 # policy:
 
 SDDP.train(model)
+
+#-
+
 simulations = SDDP.simulate(
     model,
     10,  #= number of replications =#
-    [:x, :u_sell, :u_buy];  #= variables to record =#
+    [:x, :u_sell, :u_make];  #= variables to record =#
     skip_undefined_variables = true,
 );
 
@@ -298,7 +301,7 @@ SDDP.train(model)
 simulations = SDDP.simulate(
     model,
     10,  #= number of replications =#
-    [:x, :u_sell, :u_buy];  #= variables to record =#
+    [:x, :u_sell, :u_make];  #= variables to record =#
     skip_undefined_variables = true,
 );
 

--- a/docs/src/tutorial/example_newsvendor.jl
+++ b/docs/src/tutorial/example_newsvendor.jl
@@ -68,7 +68,7 @@ model = SDDP.PolicyGraph(
     build_subproblem,
     graph;
     sense = :Max,
-    upper_bound = 5 * maximum(d),
+    upper_bound = 5 * maximum(d), #= some large upper bound =#
     optimizer = HiGHS.Optimizer,
 )
 
@@ -240,6 +240,8 @@ Plots.plot(
 #  * What happens if you can only buy and sell integer numbers of newspapers?
 #    Try this by adding `Int` to the variable definitions:
 #    `@variable(subproblem, buy >= 0, Int)`
+#  * What happens if you use a different upper bound? Try an invalid one like
+#    `-100`, and a very large one like `1e12`.
 
 # ## Other graphs
 

--- a/src/plugins/risk_measures.jl
+++ b/src/plugins/risk_measures.jl
@@ -88,6 +88,19 @@ struct AVaR <: AbstractRiskMeasure
     end
 end
 
+"""
+    CVaR(γ)
+
+The conditional value at risk (CV@R) risk measure.
+
+Computes the expectation of the γ fraction of worst outcomes. γ must be in `[0,
+1]`. When `γ=1`, this is equivalent to the [`Expectation`](@ref) risk measure.
+When `γ=0`, this is equivalent  to the [`WorstCase`](@ref) risk measure.
+
+CV@R is also known as the average value at risk (AV@R) or expected shortfall.
+"""
+const CVaR = AVaR
+
 function adjust_probability(
     measure::AVaR,
     risk_adjusted_probability::Vector{Float64},


### PR DESCRIPTION
I'm giving a few tutorials in October at https://cermics-lab.enpc.fr/seso2023/ and https://julia-users-paris.github.io/workshop/en/.

My plan is to work through a few of these examples, with little exercises at the bottom for people to try.

Preview: https://odow.github.io/SDDP.jl/previews/PR658/tutorial/example_newsvendor/