### PR TITLE
Use DOCUMENTER_KEY to deploy docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --color=yes --project=docs/ docs/make.jl
       - uses: errata-ai/vale-action@reviewdog
         with:


### PR DESCRIPTION
Actions which use `GITHUB_TOKEN` can't themselves trigger new actions: 
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

So if we upload the docs with `GITHUB_TOKEN`, it doesn't then trigger the `push` notification for the `deploy-static` action.