### PR TITLE
Add a test for non-finite data in publication_plot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
             os: ubuntu-latest
             arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -42,6 +42,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/visualization/publication_plot.jl
+++ b/src/visualization/publication_plot.jl
@@ -20,7 +20,7 @@ function publication_data(
                     "Unable to plot `publication_plot` because stage $stage " *
                     "of replication $i contains data that is not finite. " *
                     "The data function must return a finite real-valued " *
-                    "scalar. Got: $s"
+                    "scalar. Got: $s",
                 )
             end
         end

--- a/src/visualization/publication_plot.jl
+++ b/src/visualization/publication_plot.jl
@@ -14,6 +14,16 @@ function publication_data(
     output_array = fill(NaN, length(quantiles), max_stages)
     for stage in 1:max_stages
         stage_data = stage_function.([data[stage] for data in dataset])
+        for (i, s) in enumerate(stage_data)
+            if !isfinite(s)
+                error(
+                    "Unable to plot `publication_plot` because stage $stage " *
+                    "of replication $i contains data that is not finite. " *
+                    "The data function must return a finite real-valued " *
+                    "scalar. Got: $s"
+                )
+            end
+        end
         output_array[:, stage] .= Statistics.quantile(stage_data, quantiles)
     end
     return output_array

--- a/test/visualization/visualization.jl
+++ b/test/visualization/visualization.jl
@@ -57,16 +57,24 @@ function test_SpaghettiPlot()
 end
 
 function test_PublicationPlot()
-    data = SDDP.publication_data(
-        [
-            [Dict{Symbol,Any}(:x => 1), Dict{Symbol,Any}(:x => 5)],
-            [Dict{Symbol,Any}(:x => 2), Dict{Symbol,Any}(:x => 6)],
-            [Dict{Symbol,Any}(:x => 3), Dict{Symbol,Any}(:x => 4)],
-        ],
-        [0.0, 1.0],
-        (d) -> d[:x],
-    )
-    @test data == [1 4; 3 6]
+    simulations = [
+        [Dict{Symbol,Any}(:x => 1), Dict{Symbol,Any}(:x => 5)],
+        [Dict{Symbol,Any}(:x => 2), Dict{Symbol,Any}(:x => 6)],
+        [Dict{Symbol,Any}(:x => 3), Dict{Symbol,Any}(:x => 4)],
+    ]
+    data = SDDP.publication_data(simulations, [0.0, 0.25, 0.5, 1.0], d -> d[:x])
+    @test data == [1 4; 1.5 4.5; 2 5; 3 6]
+    for val in (-Inf, Inf, NaN)
+        simulations[2][2] = Dict{Symbol,Any}(:x => val)
+        @test_throws(
+            ErrorException(
+                "Unable to plot `publication_plot` because stage 2 of " *
+                "replication 2 contains data that is not finite. The data " *
+                "function must return a finite real-valued scalar. Got: $val",
+            ),
+            SDDP.publication_data(simulations, [0.5], d -> d[:x]),
+        )
+    end
     return
 end
 


### PR DESCRIPTION
Closes #737

Also errors on `NaN` because:

```julia
julia> quantile([1, NaN, 2], 0.5)
ERROR: ArgumentError: quantiles are undefined in presence of NaNs or missing values
Stacktrace:
 [1] _quantilesort!(v::Vector{Float64}, sorted::Bool, minp::Float64, maxp::Float64)
   @ Statistics ~/.julia/juliaup/julia-1.10.2+0.x64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:994
 [2] quantile!(v::Vector{Float64}, p::Float64; sorted::Bool, alpha::Float64, beta::Float64)
   @ Statistics ~/.julia/juliaup/julia-1.10.2+0.x64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:976
 [3] quantile!
   @ ~/.julia/juliaup/julia-1.10.2+0.x64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:976 [inlined]
 [4] quantile(v::Vector{Float64}, p::Float64)
   @ Statistics ~/.julia/juliaup/julia-1.10.2+0.x64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:1089
 [5] top-level scope
   @ REPL[10]:1
```