### PR TITLE
Add Threaded parallel scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -68,6 +68,7 @@ SDDP.SimulatorSamplingScheme
 ```@docs
 SDDP.AbstractParallelScheme
 SDDP.Serial
+SDDP.Threaded
 SDDP.Asynchronous
 ```
 

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -851,7 +851,7 @@ function iteration(model::PolicyGraph{T}, options::Options) where {T}
                 bound,
                 forward_trajectory.cumulative_value,
                 time() - options.start_time,
-                Distributed.myid(),
+                max(Threads.threadid(), Distributed.myid()),
                 model.ext[:total_solves],
                 duality_log_key(options.duality_handler),
                 model.ext[:numerical_issue],
@@ -863,7 +863,7 @@ function iteration(model::PolicyGraph{T}, options::Options) where {T}
     has_converged, status =
         convergence_test(model, options.log, options.stopping_rules)
     return IterationResult(
-        Distributed.myid(),
+        max(Threads.threadid(), Distributed.myid()),
         bound,
         forward_trajectory.cumulative_value,
         has_converged,

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -672,8 +672,11 @@ function solve_all_children(
         child_node = model[child.term]
         lock(child_node.lock)  # LOCK-ID-004
         @_timeit_threadsafe model.timer_output "prepare_backward_pass" begin
-            restore_duality =
-                prepare_backward_pass(node, options.duality_handler, options)
+            restore_duality = prepare_backward_pass(
+                child_node,
+                options.duality_handler,
+                options,
+            )
         end
         for noise in sample_backward_noise_terms_with_state(
             backward_sampling_scheme,

--- a/src/plugins/duality_handlers.jl
+++ b/src/plugins/duality_handlers.jl
@@ -61,24 +61,6 @@ SDDiP(args...; kwargs...) = _deprecate_integrality_handler()
 
 ContinuousRelaxation(args...; kwargs...) = _deprecate_integrality_handler()
 
-function prepare_backward_pass(
-    model::PolicyGraph,
-    duality_handler::AbstractDualityHandler,
-    options::Options,
-)
-    undo = Function[]
-    for (_, node) in model.nodes
-        push!(undo, prepare_backward_pass(node, duality_handler, options))
-    end
-    function undo_relax()
-        for f in undo
-            f()
-        end
-        return
-    end
-    return undo_relax
-end
-
 function get_dual_solution(node::Node, ::Nothing)
     return JuMP.objective_value(node.subproblem), Dict{Symbol,Float64}()
 end
@@ -351,8 +333,10 @@ focus more on the more-recent rewards.
 mutable struct BanditDuality <: AbstractDualityHandler
     arms::Vector{_BanditArm}
     last_arm_index::Int
+    logs_seen::Int
+
     function BanditDuality(args::AbstractDualityHandler...)
-        return new(_BanditArm[_BanditArm(arg, Float64[]) for arg in args], 1)
+        return new(_BanditArm[_BanditArm(arg, Float64[]) for arg in args], 1, 0)
     end
 end
 
@@ -404,15 +388,16 @@ function _update_rewards(handler::BanditDuality, log::Vector{Log})
 end
 
 function prepare_backward_pass(
-    model::PolicyGraph,
+    node::Node,
     handler::BanditDuality,
     options::Options,
 )
-    if length(options.log) > 1
+    if length(options.log) > handler.logs_seen
         _update_rewards(handler, options.log)
+        handler.logs_seen = length(options.log)
     end
     arm = _choose_best_arm(handler)
-    return prepare_backward_pass(model, arm.handler, options)
+    return prepare_backward_pass(node, arm.handler, options)
 end
 
 function get_dual_solution(node::Node, handler::BanditDuality)

--- a/src/plugins/duality_handlers.jl
+++ b/src/plugins/duality_handlers.jl
@@ -336,7 +336,7 @@ mutable struct BanditDuality <: AbstractDualityHandler
     logs_seen::Int
 
     function BanditDuality(args::AbstractDualityHandler...)
-        return new(_BanditArm[_BanditArm(arg, Float64[]) for arg in args], 1, 0)
+        return new(_BanditArm[_BanditArm(arg, Float64[]) for arg in args], 1, 1)
     end
 end
 

--- a/src/plugins/parallel_schemes.jl
+++ b/src/plugins/parallel_schemes.jl
@@ -331,7 +331,21 @@ end
 """
     Threaded()
 
-Run SDDP in threaded mode.
+Run SDDP in multi-threaded mode.
+
+Use `julia --threads N` to start Julia with `N` threads. In most cases, you
+should pick `N` to be the number of physical cores on your machine.
+
+!!! danger
+    This plug-in is experimental, and parts of SDDP.jl may not be threadsafe. If
+    you encounter any problems or crashes, please open a GitHub issue.
+
+## Example
+
+```julia
+SDDP.train(model; parallel_scheme = SDDP.Threaded())
+SDDP.simulate(model; parallel_scheme = SDDP.Threaded())
+```
 """
 struct Threaded <: AbstractParallelScheme end
 

--- a/src/plugins/parallel_schemes.jl
+++ b/src/plugins/parallel_schemes.jl
@@ -350,6 +350,7 @@ function master_loop(
         lock(options.lock) do
             options.post_iteration_callback(result)
             log_iteration(options)
+            return
         end
         if result.has_converged
             return result.status
@@ -372,6 +373,7 @@ function _simulate(
         simulation = _simulate(model, variables; kwargs...)
         lock(ret_lock) do
             push!(ret, simulation)
+            return
         end
     end
     return ret

--- a/src/user_interface.jl
+++ b/src/user_interface.jl
@@ -661,6 +661,8 @@ mutable struct Node{T}
     # An extension dictionary. This is a useful place for packages that extend
     # SDDP.jl to stash things.
     ext::Dict{Symbol,Any}
+    # Lock for threading
+    lock::ReentrantLock
 end
 
 function Base.show(io::IO, node::Node)
@@ -990,6 +992,7 @@ function PolicyGraph(
             direct_mode ? nothing : optimizer,
             # The extension dictionary.
             Dict{Symbol,Any}(),
+            ReentrantLock(),
         )
         subproblem.ext[:sddp_policy_graph] = policy_graph
         policy_graph.nodes[node_index] = subproblem.ext[:sddp_node] = node

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -20,6 +20,24 @@ function runtests()
     return
 end
 
+function SDDP.prepare_backward_pass(
+    model::SDDP.PolicyGraph,
+    duality_handler::SDDP.AbstractDualityHandler,
+    options::SDDP.Options,
+)
+    undo = Function[]
+    for (_, node) in model.nodes
+        push!(undo, SDDP.prepare_backward_pass(node, duality_handler, options))
+    end
+    function undo_relax()
+        for f in undo
+            f()
+        end
+        return
+    end
+    return undo_relax
+end
+
 # Single-stage model helps set up a node and subproblem to test dual
 # calculations
 function easy_single_stage(duality_handler)

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -428,7 +428,7 @@ function test_BanditDuality_show()
     return
 end
 
-function test_BanditDuality_show()
+function test_BanditDuality_eval()
     model = SDDP.LinearPolicyGraph(
         stages = 2,
         lower_bound = -100.0,

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -51,7 +51,7 @@ function test_threaded()
         custom_recorders = recorder,
     )
     thread_ids_seen =
-        Set{Int}(data[:thread_id] for sim in simulations, data in sim)
+        Set{Int}(data[:thread_id] for sim in simulations for data in sim)
     min_threads = Threads.nthreads() > 1 ? 1 : 2
     @test min_threads <= length(thread_ids_seen) <= Threads.nthreads()
     return

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -41,7 +41,7 @@ function test_threaded()
     SDDP.train(model; iteration_limit = 100, parallel_scheme = SDDP.Threaded())
     thread_ids_seen =
         Set{Int}(log.pid for log in model.most_recent_training_results.log)
-    min_threads = Threads.nthreads() > 1 ? 1 : 2
+    min_threads = Threads.nthreads() == 1 ? 1 : 2
     @test min_threads <= length(thread_ids_seen) <= Threads.nthreads()
     recorder = Dict{Symbol,Function}(:thread_id => sp -> Threads.threadid())
     simulations = SDDP.simulate(

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -1,0 +1,77 @@
+#  Copyright (c) 2017-23, Oscar Dowson and SDDP.jl contributors.
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+function test_threaded()
+    num_periods = 24
+    num_thermal = 5
+    num_battery = 2
+    c_capacity = 14
+    c_VOLL = 35
+    c_eta = [0.8, 0.5]
+    c_pt = [2, 5, 8, 11, 14]
+    c_q = fill(c_capacity, 5)
+    df_demand = rand(10:10:60, num_periods)
+    model = SDDP.LinearPolicyGraph(;
+        stages = num_periods,
+        sense = :Min,
+        lower_bound = 0.0,
+        optimizer = HiGHS.Optimizer,
+    ) do subproblem, t
+        @variables(subproblem, begin
+            0 <= x_volume[1:num_battery] <= 8, SDDP.State, (initial_value = 1)
+            u_u[1:num_battery] >= 0
+            u_v[1:num_battery] >= 0
+            0 <= u_x[i in 1:num_thermal] <= c_q[i]
+            u_slack >= 0
+            w_noise
+        end)
+        @constraints(subproblem, begin
+            battery[j in 1:num_battery],
+                x_volume[j].out == x_volume[j].in + c_eta[j] * u_v[j] - u_u[j]
+            sum(u_x) + sum(u_u) - sum(u_v) + u_slack == df_demand[t] + w_noise
+        end)
+        O = [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]
+        SDDP.parameterize(subproblem, O) do omega
+            JuMP.fix(w_noise, omega)
+            return
+        end
+        @stageobjective(subproblem, c_pt' * u_x + u_slack * c_VOLL)
+        return
+    end
+    SDDP.train(
+        model;
+        iteration_limit = 100,
+        parallel_scheme = SDDP.Threaded(),
+    )
+    thread_ids_seen =
+        Set{Int}(log.pid for log in model.most_recent_training_results.log)
+    if Threads.nthreads() == 1
+        @test length(thread_ids_seen) == 1
+    else
+        @test length(thread_ids_seen) > 1
+    end
+    simulations = SDDP.simulate(
+        model,
+        100;
+        parallel_scheme = SDDP.Threaded(),
+        custom_recorders = Dict{Symbol, Function}(
+            :thread_id => sp -> Threads.threadid(),
+        ),
+    )
+    thread_ids_seen = Set{Int}()
+    for sim in simulations
+        thread_ids = unique(data[:thread_id] for data in sim)
+        @test length(thread_ids) == 1
+        push!(thread_ids_seen, only(thread_ids))
+    end
+    if Threads.nthreads() == 1
+        @test length(thread_ids_seen) == 1
+    else
+        @test length(thread_ids_seen) > 1
+    end
+    return
+end
+
+test_threaded()

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -4,73 +4,56 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 function test_threaded()
-    num_periods = 24
-    num_thermal = 5
-    num_battery = 2
-    c_capacity = 14
-    c_VOLL = 35
-    c_eta = [0.8, 0.5]
-    c_pt = [2, 5, 8, 11, 14]
-    c_q = fill(c_capacity, 5)
-    df_demand = rand(10:10:60, num_periods)
+    c_eta, c_pt = [0.8, 0.5], [2, 5, 8, 11, 14]
+    df_demand = rand(10:10:60, 24)
     model = SDDP.LinearPolicyGraph(;
-        stages = num_periods,
+        stages = 24,
         sense = :Min,
         lower_bound = 0.0,
         optimizer = HiGHS.Optimizer,
     ) do subproblem, t
-        @variables(subproblem, begin
-            0 <= x_volume[1:num_battery] <= 8, SDDP.State, (initial_value = 1)
-            u_u[1:num_battery] >= 0
-            u_v[1:num_battery] >= 0
-            0 <= u_x[i in 1:num_thermal] <= c_q[i]
-            u_slack >= 0
-            w_noise
-        end)
-        @constraints(subproblem, begin
-            battery[j in 1:num_battery],
-                x_volume[j].out == x_volume[j].in + c_eta[j] * u_v[j] - u_u[j]
-            sum(u_x) + sum(u_u) - sum(u_v) + u_slack == df_demand[t] + w_noise
-        end)
-        O = [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]
-        SDDP.parameterize(subproblem, O) do omega
-            JuMP.fix(w_noise, omega)
-            return
+        @variable(
+            subproblem,
+            0 <= x_volume[1:2] <= 8,
+            SDDP.State,
+            initial_value = 1,
+        )
+        @variable(subproblem, u_u[1:2] >= 0)
+        @variable(subproblem, u_v[1:2] >= 0)
+        @variable(subproblem, 0 <= u_x[1:5] <= 5)
+        @variable(subproblem, u_slack >= 0)
+        @variable(subproblem, w_noise)
+        @constraint(
+            subproblem,
+            [j in 1:2],
+            x_volume[j].out == x_volume[j].in + c_eta[j] * u_v[j] - u_u[j],
+        )
+        @constraint(
+            subproblem,
+            sum(u_x) + sum(u_u) - sum(u_v) + u_slack == df_demand[t] + w_noise,
+        )
+        SDDP.parameterize(subproblem, [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]) do w
+            return JuMP.fix(w_noise, w)
         end
-        @stageobjective(subproblem, c_pt' * u_x + u_slack * c_VOLL)
+        @stageobjective(subproblem, c_pt' * u_x + 35 * u_slack)
         return
     end
-    SDDP.train(
-        model;
-        iteration_limit = 100,
-        parallel_scheme = SDDP.Threaded(),
-    )
+    SDDP.train(model; iteration_limit = 100, parallel_scheme = SDDP.Threaded())
     thread_ids_seen =
         Set{Int}(log.pid for log in model.most_recent_training_results.log)
-    if Threads.nthreads() == 1
-        @test length(thread_ids_seen) == 1
-    else
-        @test length(thread_ids_seen) > 1
-    end
+    min_threads = Threads.nthreads() > 1 ? 1 : 2
+    @test min_threads <= length(thread_ids_seen) <= Threads.nthreads()
+    recorder = Dict{Symbol,Function}(:thread_id => sp -> Threads.threadid())
     simulations = SDDP.simulate(
         model,
         100;
         parallel_scheme = SDDP.Threaded(),
-        custom_recorders = Dict{Symbol, Function}(
-            :thread_id => sp -> Threads.threadid(),
-        ),
+        custom_recorders = recorder,
     )
-    thread_ids_seen = Set{Int}()
-    for sim in simulations
-        thread_ids = unique(data[:thread_id] for data in sim)
-        @test length(thread_ids) == 1
-        push!(thread_ids_seen, only(thread_ids))
-    end
-    if Threads.nthreads() == 1
-        @test length(thread_ids_seen) == 1
-    else
-        @test length(thread_ids_seen) > 1
-    end
+    thread_ids_seen =
+        Set{Int}(data[:thread_id] for sim in simulations, data in sim)
+    min_threads = Threads.nthreads() > 1 ? 1 : 2
+    @test min_threads <= length(thread_ids_seen) <= Threads.nthreads()
     return
 end
 

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -4,6 +4,11 @@
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 function test_threaded()
+    # We should test that JULIA_NUM_THREADS is set in CI jobs
+    if get(ENV, "CI", "false") == "true"
+        @test get(ENV, "JULIA_NUM_THREADS", 0) == Threads.nthreads()
+        @test Threads.nthreads() > 1
+    end
     c_eta, c_pt = [0.8, 0.5], [2, 5, 8, 11, 14]
     df_demand = rand(10:10:60, 24)
     model = SDDP.LinearPolicyGraph(;

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -25,7 +25,7 @@ function test_threaded()
         )
         @variable(subproblem, u_u[1:2] >= 0)
         @variable(subproblem, u_v[1:2] >= 0)
-        @variable(subproblem, 0 <= u_x[1:5] <= 5)
+        @variable(subproblem, 0 <= u_x[1:5] <= 5, Int)
         @variable(subproblem, u_slack >= 0)
         @variable(subproblem, w_noise)
         @constraint(

--- a/test/plugins/threaded.jl
+++ b/test/plugins/threaded.jl
@@ -6,7 +6,8 @@
 function test_threaded()
     # We should test that JULIA_NUM_THREADS is set in CI jobs
     if get(ENV, "CI", "false") == "true"
-        @test get(ENV, "JULIA_NUM_THREADS", 0) == Threads.nthreads()
+        num_threads = get(ENV, "JULIA_NUM_THREADS", "0")
+        @test parse(Int, num_threads) == Threads.nthreads()
         @test Threads.nthreads() > 1
     end
     c_eta, c_pt = [0.8, 0.5], [2, 5, 8, 11, 14]


### PR DESCRIPTION
Closes #599

This is heading in the right direction:
```Julia
julia> @time simulations = SDDP.simulate(
           model,
           10_000;
           parallel_scheme = SDDP.Threaded(),
           custom_recorders = Dict{Symbol, Function}(
               :thread_id => sp -> Threads.threadid(),
           ),
       );
 14.560144 seconds (58.22 M allocations: 2.101 GiB, 5.02% gc time, 0.06% compilation time)

julia> @time simulations = SDDP.simulate(
           model,
           10_000;
           parallel_scheme = SDDP.Serial(),
           custom_recorders = Dict{Symbol, Function}(
               :thread_id => sp -> Threads.threadid(),
           ),
       );
 47.935609 seconds (58.31 M allocations: 2.106 GiB, 2.24% gc time, 0.10% compilation time)
```

Avoiding the various race conditions is a bit fiddly though.

## TODOs

 - [x] integer stuff?