### PR TITLE
Cut selection flags for write and read cuts functions

### DIFF
--- a/src/plugins/bellman_functions.jl
+++ b/src/plugins/bellman_functions.jl
@@ -638,7 +638,7 @@ function write_cuts_to_file(
     model::PolicyGraph{T},
     filename::String;
     node_name_parser::Function = string,
-    write_only_selected_cuts::Bool = false
+    write_only_selected_cuts::Bool = false,
 ) where {T}
     cuts = Dict{String,Any}[]
     for (node_name, node) in model.nodes

--- a/src/plugins/bellman_functions.jl
+++ b/src/plugins/bellman_functions.jl
@@ -673,7 +673,9 @@ function write_cuts_to_file(
         end
         for (i, theta) in enumerate(node.bellman_function.local_thetas)
             for (cut, state) in zip(theta.cuts, theta.sampled_states)
-                if !write_only_selected_cuts || cut.constraint_ref !== nothing
+                if write_only_selected_cuts && cut.constraint_ref === nothing
+                    continue
+                end
                     intercept = cut.intercept
                     for (key, π) in cut.coefficients
                         intercept += π * state.state[key]

--- a/src/plugins/bellman_functions.jl
+++ b/src/plugins/bellman_functions.jl
@@ -619,7 +619,7 @@ end
     write_cuts_to_file(
         model::PolicyGraph{T},
         filename::String;
-        kwargs...
+        kwargs...,
     ) where {T}
 
 Write the cuts that form the policy in `model` to `filename` in JSON format.
@@ -657,8 +657,8 @@ function write_cuts_to_file(
         oracle = node.bellman_function.global_theta
         for (cut, state) in zip(oracle.cuts, oracle.sampled_states)
             if write_only_selected_cuts && cut.constraint_ref === nothing
-                    continue
-                end
+                continue
+            end
             intercept = cut.intercept
             for (key, π) in cut.coefficients
                 intercept += π * state.state[key]
@@ -726,7 +726,7 @@ end
     read_cuts_from_file(
         model::PolicyGraph{T},
         filename::String;
-        kwargs...
+        kwargs...,
     ) where {T}
 
 Read cuts (saved using [`SDDP.write_cuts_to_file`](@ref)) from `filename` into

--- a/src/plugins/bellman_functions.jl
+++ b/src/plugins/bellman_functions.jl
@@ -656,40 +656,40 @@ function write_cuts_to_file(
         )
         oracle = node.bellman_function.global_theta
         for (cut, state) in zip(oracle.cuts, oracle.sampled_states)
-            if !write_only_selected_cuts || cut.constraint_ref !== nothing
-                intercept = cut.intercept
-                for (key, π) in cut.coefficients
-                    intercept += π * state.state[key]
+            if write_only_selected_cuts && cut.constraint_ref === nothing
+                    continue
                 end
-                push!(
-                    node_cuts["single_cuts"],
-                    Dict(
-                        "intercept" => intercept,
-                        "coefficients" => copy(cut.coefficients),
-                        "state" => copy(state.state),
-                    ),
-                )
+            intercept = cut.intercept
+            for (key, π) in cut.coefficients
+                intercept += π * state.state[key]
             end
+            push!(
+                node_cuts["single_cuts"],
+                Dict(
+                    "intercept" => intercept,
+                    "coefficients" => copy(cut.coefficients),
+                    "state" => copy(state.state),
+                ),
+            )
         end
         for (i, theta) in enumerate(node.bellman_function.local_thetas)
             for (cut, state) in zip(theta.cuts, theta.sampled_states)
                 if write_only_selected_cuts && cut.constraint_ref === nothing
                     continue
                 end
-                    intercept = cut.intercept
-                    for (key, π) in cut.coefficients
-                        intercept += π * state.state[key]
-                    end
-                    push!(
-                        node_cuts["multi_cuts"],
-                        Dict(
-                            "realization" => i,
-                            "intercept" => intercept,
-                            "coefficients" => copy(cut.coefficients),
-                            "state" => copy(state.state),
-                        ),
-                    )
+                intercept = cut.intercept
+                for (key, π) in cut.coefficients
+                    intercept += π * state.state[key]
                 end
+                push!(
+                    node_cuts["multi_cuts"],
+                    Dict(
+                        "realization" => i,
+                        "intercept" => intercept,
+                        "coefficients" => copy(cut.coefficients),
+                        "state" => copy(state.state),
+                    ),
+                )
             end
         end
         for p in node.bellman_function.risk_set_cuts


### PR DESCRIPTION
Related with #778, this PR adds: 
- cut_selection flag to use or not the cut selection algorithm when reading the files: This will significantly reduce the time to load a file
- write_only_selected_cuts to write only the selected cuts: This will reduce the file size and reading time significantly