### PR TITLE
Improving user interfaces and test coverage in fpc/inner

### DIFF
--- a/src/Inner.jl
+++ b/src/Inner.jl
@@ -74,18 +74,11 @@ end
 # TODO(bfpc): implement Objective and Belief states
 function _add_vertex_var_to_model(V::InnerConvexApproximation, vertex::Vertex)
     model = JuMP.owner_model(V.theta)
-    yᵀμ = JuMP.AffExpr(0.0)
     if V.objective_states !== nothing
         error("Objective states not yet implemented.")
-        for (y, μ) in zip(cut.obj_y, V.objective_states)
-            JuMP.add_to_expression!(yᵀμ, y, μ)
-        end
     end
     if V.belief_states !== nothing
         error("Belief states not yet implemented.")
-        for (k, μ) in V.belief_states
-            JuMP.add_to_expression!(yᵀμ, cut.belief_y[k], μ)
-        end
     end
 
     # Add a new variable to the convex combination constraints

--- a/test/Inner.jl
+++ b/test/Inner.jl
@@ -167,7 +167,7 @@ function create_policy_graph_with_inner_approximation()
     # lipschitz estimates used in the test_Read_write_cuts_to_file
     # makes the test for calculating bound after training fails
 
-    return Inner.InnerPolicyGraph(
+    return SDDP.Inner.InnerPolicyGraph(
         build,
         graph;
         lower_bound = 0.0,
@@ -187,6 +187,21 @@ function test_simulate_with_inner_approximation()
     model = create_policy_graph_with_inner_approximation()
     SDDP.train(model; iteration_limit = 50, print_level = 0)
     SDDP.simulate(model, 50, [:vertex_coverage_distance])
+end
+
+function test_from_outer_policy_graph()
+    nstages = 4
+    graph = SDDP.LinearGraph(nstages)
+    cut_model = _create_model(graph)
+    SDDP.train(cut_model; iteration_limit = 50, print_level = 0)
+    vertex_model = create_policy_graph_with_inner_approximation()
+    SDDP.Inner.from_outer_policy_graph(
+        vertex_model,
+        cut_model;
+        optimizer = HiGHS.Optimizer,
+    )
+    @test SDDP.calculate_bound(vertex_model) ≈ 45.833 atol = 0.1
+
 end
 
 end  # module


### PR DESCRIPTION
Contains some small improvements to the user interface while using the inner approximations. In general, the `inner_dp` function content was divided in smaller pieces:

- Adds an `InnerPolicyGraph` constructor that works in a similar way to the `SDDP.PolicyGraph`. By using it, the user does not need to explicitly build the `InnerBellmanFunction` object.
- Adds an `read_vertices_from_policy_graph` function that performes the single dynamic programming iteration from `inner_dp`, but receiving an object obtained from the `InnerPolicyGraph` constructor, without calculating bounds at the same time
- Adds some validations for arguments in these function calls

Also, the test coverage should be slightly improved with respect to the previous patch.

