### PR TITLE
Add a fallback optimizer in duality handlers

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -12,6 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 HiGHS = "1"
+Ipopt = "1"
 JSON = "0.21"
 JSONSchema = "1"
 Plots = "1"

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -477,6 +477,43 @@ function test_deprecate_integrality_handler()
     return
 end
 
+function test_duality_handler_with_fallback_optimizer()
+    function _train_model_with_duality_handler(duality_handler)
+        model = SDDP.LinearPolicyGraph(
+            stages = 3,
+            lower_bound = 0.0,
+            optimizer = HiGHS.Optimizer,
+        ) do sp, t
+            @variable(sp, 0 <= x <= 10, SDDP.State, Int, initial_value = 1)
+            @constraint(sp, x.out >= x.in)
+            @stageobjective(sp, x.out)
+        end
+        SDDP.train(model; print_level = 0, duality_handler)
+        return model
+    end
+    n_calls = Ref{Int}(0)
+    function my_optimizer()
+        n_calls[] += 1
+        return Ipopt.Optimizer()
+    end
+    for (duality_handler, keys) in (
+        SDDP.ContinuousConicDuality => (" ",),
+        SDDP.StrengthenedConicDuality => ("S",),
+        SDDP.LagrangianDuality => ("L",),
+        SDDP.BanditDuality => (" ", "S"),
+    )
+        n_calls[] = 0
+        handler = duality_handler(my_optimizer)
+        model = _train_model_with_duality_handler(handler)
+        @test isapprox(SDDP.calculate_bound(model), 3.0; atol = 1e-6)
+        @test n_calls[] > 0
+        for iteration in model.most_recent_training_results.log
+            @test iteration.duality_key in keys
+        end
+    end
+    return
+end
+
 end
 
 TestDualityHandlers.runtests()

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -424,7 +424,7 @@ end
 
 function test_BanditDuality_show()
     @test sprint(show, SDDP.BanditDuality()) ==
-          "BanditDuality with arms:\n * SDDP.ContinuousConicDuality()\n * SDDP.StrengthenedConicDuality()"
+          "BanditDuality with arms:\n * SDDP.ContinuousConicDuality{Nothing}(nothing)\n * SDDP.StrengthenedConicDuality{Nothing}(nothing)"
     return
 end
 

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -8,6 +8,7 @@ module TestDualityHandlers
 using SDDP
 using Test
 import HiGHS
+import Ipopt
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -480,7 +480,7 @@ end
 
 function test_duality_handler_with_fallback_optimizer()
     function _train_model_with_duality_handler(duality_handler)
-        model = SDDP.LinearPolicyGraph(
+        model = SDDP.LinearPolicyGraph(;
             stages = 3,
             lower_bound = 0.0,
             optimizer = HiGHS.Optimizer,


### PR DESCRIPTION
Closes #844

Some primal solvers may not be able to produce duals, even if the integrality is relaxed.