### PR TITLE
Add FixedDiscreteDuality

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -347,6 +347,11 @@ SDDP.StrengthenedConicDuality
 SDDP.BanditDuality
 ```
 
+## `FixedDiscreteDuality`
+```@docs
+SDDP.FixedDiscreteDuality
+```
+
 ## `simulate`
 ```@docs
 SDDP.simulate

--- a/test/plugins/duality_handlers.jl
+++ b/test/plugins/duality_handlers.jl
@@ -515,6 +515,26 @@ function test_duality_handler_with_fallback_optimizer()
     return
 end
 
+function test_FixedDiscreteDuality()
+    model = SDDP.LinearPolicyGraph(;
+        stages = 2,
+        lower_bound = 0.0,
+        optimizer = HiGHS.Optimizer,
+    ) do sp, t
+        @variable(sp, x, SDDP.State, Int, initial_value = 0)
+        @constraint(sp, x.out >= x.in + 0.5)
+        @stageobjective(sp, x.out)
+    end
+    SDDP.train(
+        model;
+        duality_handler = SDDP.FixedDiscreteDuality(),
+        print_level = 0,
+    )
+    @test SDDP.calculate_bound(model) ≈ 3.0
+    @test SDDP.duality_log_key(SDDP.FixedDiscreteDuality()) == "F"
+    return
+end
+
 end
 
 TestDualityHandlers.runtests()


### PR DESCRIPTION
Motivated by this forum discussion: https://or.stackexchange.com/questions/13191/benders-cuts-discrete-variables

This was actually the technique Tony and I used for the original MilkOutputOptimizer model in 2014.

Edit: I plucked up the courage to upload the report: https://github.com/odow/SDDP.jl/blob/master/papers/other/dowson_2014.pdf

The relevant part of the report _massively_ glosses over the details (like the fact the cuts might be invalid):

<img width="719" alt="image" src="https://github.com/user-attachments/assets/e6c581fe-a471-42db-8bb8-61e1dc20cd7a" />

Historical tidbit: the first version of SDDP.jl used gurobipy...

<img width="463" alt="image" src="https://github.com/user-attachments/assets/3837918e-b5e4-4864-b52f-bb9ae0b138f1" />
